### PR TITLE
Back to good ol' Sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtrelease.ReleaseStateTransformations._
+
 name := "content-api-models"
 
 organization := "com.gu"
@@ -6,11 +8,42 @@ libraryDependencies ++= Seq(
   "com.gu" % "content-atom-model-thrift" % "1.0.0"
 )
 scalaVersion := "2.11.8"
+crossPaths := false
+
+unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
+
 publishMavenStyle := true
 publishArtifact in Test := false
-bintrayOrganization := Some("guardian")
-bintrayRepository := "platforms"
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+releaseProcess := Seq(
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  publishArtifacts,
+  setNextVersion,
+  commitNextVersion,
+  releaseStepCommand("sonatypeReleaseAll"),
+  pushChanges
+)
+
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
-publishArtifact in packageDoc := false
-unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
-crossPaths := false
+pomExtra := (
+  <url>https://github.com/guardian/content-api-models</url>
+  <scm>
+    <connection>scm:git:git@github.com:guardian/content-api-models.git</connection>
+    <developerConnection>scm:git:git@github.com:guardian/content-api-models.git</developerConnection>
+    <url>git@github.com:guardian/content-api-models.git</url>
+  </scm>
+  <developers>
+    <developer>
+      <id>cb372</id>
+      <name>Chris Birchall</name>
+      <url>https://github.com/cb372</url>
+    </developer>
+  </developers>
+)
+pomIncludeRepository := { _ => false }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "8.2-SNAPSHOT"
+version in ThisBuild := "8.1.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "8.1.2"
+version in ThisBuild := "8.2-SNAPSHOT"


### PR DESCRIPTION
The world is not quite ready for Bintray. Let's go back to the tried and tested Maven Central via Sonatype method for publishing.

See https://github.com/sbt/sbt/issues/2464 for more details. Basically JCenter had some reliability problems, so it's disabled by default in sbt for now. Telling our users to enable it is quite a big ask.