### PR TITLE
Add packages to json parser

### DIFF
--- a/json/src/main/scala/com.gu.contentapi.json/JsonParser.scala
+++ b/json/src/main/scala/com.gu.contentapi.json/JsonParser.scala
@@ -50,6 +50,10 @@ object JsonParser {
     (JsonMethods.parse(json) \ "response").extract[VideoStatsResponse]
   }
 
+  def parsePackages(json: String): PackageResponse = {
+    (JsonMethods.parse(json) \ "response").extract[PackageResponse]
+  }
+
   def parseError(json: String): Option[ErrorResponse] = for {
     parsedJson <- JsonMethods.parseOpt(json)
     response = parsedJson \ "response"

--- a/json/src/test/resources/templates/packages.json
+++ b/json/src/test/resources/templates/packages.json
@@ -1,0 +1,64 @@
+{
+  "response": {
+    "status": "ok",
+    "userTier": "developer",
+    "total": 39841,
+    "startIndex": 1,
+    "pageSize": 10,
+    "currentPage": 1,
+    "pages": 3985,
+    "orderBy": "newest",
+    "results": [
+      {
+        "packageId": "a2665327-e426-423b-a923-319a56c76460",
+        "packageName": "Tata steel crisis",
+        "lastModified": "2016-04-18T12:41:40.622Z"
+      },
+      {
+        "packageId": "0f7fa558-54ac-4fc2-8af5-93849944b2e0",
+        "packageName": "Drones + planes in UK",
+        "lastModified": "2016-04-18T12:21:37.612Z"
+      },
+      {
+        "packageId": "ffe8ccf8-60e8-4694-962a-32ec75e1f0e2",
+        "packageName": "Nelson's column protest",
+        "lastModified": "2016-04-18T12:15:16.244Z"
+      },
+      {
+        "packageId": "2fdd2540-e7be-45e0-a382-0e6919ab885d",
+        "packageName": "Housing bill",
+        "lastModified": "2016-04-18T11:13:57.321Z"
+      },
+      {
+        "packageId": "18978af6-a5c0-40fc-9adb-ac6d161c53eb",
+        "packageName": "Ecuador earthquake",
+        "lastModified": "2016-04-18T10:18:23.030Z"
+      },
+      {
+        "packageId": "7e58c44a-8a3c-4a10-bc94-33bf551eec0b",
+        "packageName": "eu referendum",
+        "lastModified": "2016-04-18T10:16:23.462Z"
+      },
+      {
+        "packageId": "ad698234-9e70-4a6a-b306-69f2bf859732",
+        "packageName": "new ecuador quake",
+        "lastModified": "2016-04-18T10:03:40.379Z"
+      },
+      {
+        "packageId": "73817193-e5e6-11e5-8b19-4b0968a5a8b5",
+        "packageName": "Oscar Pistorius",
+        "lastModified": "2016-04-18T08:22:47.605Z"
+      },
+      {
+        "packageId": "4e3fce3d-a482-464a-8793-aa0d92aa0879",
+        "packageName": "yemen conflict",
+        "lastModified": "2016-04-18T08:14:00.026Z"
+      },
+      {
+        "packageId": "25e1f688-abe3-4a3e-a31d-4499bde9f204",
+        "packageName": "cuba raul castro communist party",
+        "lastModified": "2016-04-17T22:38:43.781Z"
+      }
+    ]
+  }
+}

--- a/json/src/test/scala/com/gu/contentapi/json/JsonParserPackagesTest.scala
+++ b/json/src/test/scala/com/gu/contentapi/json/JsonParserPackagesTest.scala
@@ -1,0 +1,26 @@
+package com.gu.contentapi.json
+
+import org.scalatest.{FlatSpec, Matchers}
+import com.gu.contentapi.json.utils.JsonLoader.loadJson
+
+class JsonParserPackagesTest extends FlatSpec with Matchers {
+
+  val packagesResponse = JsonParser.parsePackages(loadJson("packages.json"))
+
+  "packages parser" should "parse basic response fields" in {
+    packagesResponse.status should be ("ok")
+    packagesResponse.userTier should be ("developer")
+    packagesResponse.total should be (39841)
+    packagesResponse.startIndex should be (1)
+    packagesResponse.pageSize should be (10)
+    packagesResponse.currentPage should be (1)
+    packagesResponse.pages should be (3985)
+  }
+
+  it should "parse the packages" in {
+    packagesResponse.results.size should be (10)
+    packagesResponse.results.head.packageId should be ("a2665327-e426-423b-a923-319a56c76460")
+    packagesResponse.results.head.packageName should be ("Tata steel crisis")
+  }
+
+}


### PR DESCRIPTION
This is currently required by Concierge, and may at some point be needed by content-api-scala-client