### PR TITLE
Sort out the Scrooge/libthrift dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,8 +66,6 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     description := "Scala models for the Guardian's Content API",
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.9.2",
-      "com.twitter" %% "scrooge-core" % "3.20.0",
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
       "com.gu" % "content-atom-model-thrift" % "1.0.0"
     )
@@ -97,6 +95,8 @@ lazy val json = Project(id = "content-api-models-json", base = file("json"))
     },
 
     libraryDependencies ++= Seq(
+      "org.apache.thrift" % "libthrift" % "0.9.1",
+      "com.twitter" %% "scrooge-core" % "4.5.0",
       "org.json4s" %% "json4s-jackson" % "3.3.0",
       "org.json4s" %% "json4s-ext" % "3.3.0",
       "joda-time" % "joda-time" % "2.3",


### PR DESCRIPTION
* Move the dependencies to the `json` project where they belong
* Scrooge should be 4.5.0 to match what we use in other projects
* Downgrade libthrift to 0.9.1 to fix the incompatible equals() change

The reason for downgrading libthrift is that Scrooge is compiled against libthrift 0.5.0-1 (Twitter's fork), which turns out to be incompatible with 0.9.2 or newer. 
When it deserializes a struct containing one or more optional fields that it doesn't understand, its `equals` method delegates to the one provided by `libthrift`. But the signature of that method changed between 0.9.1 and 0.9.2. [Here](https://github.com/apache/thrift/commit/97243a73eab86b634540756f72be1c500cfeea6c#diff-decddb5b3bdeea999d3c19fa200d3bfcR56) is the change that cost us a whole day of debugging, nestled away inside an innocuous-sounding commit called "Address FindBugs errors".

If we discover any more surprises like this, I recommend we downgrade further to 0.5.0-1, which is known to work well with Scrooge.

@davidfurey Please tell me if any of the above explanation is incorrect
/cc @tomrf1 