### PR TITLE
Adds paidContentType and aboutLink commercial fields

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -810,7 +810,7 @@ struct Reference {
 struct PodcastCategory {
 
     1: required string main
-    
+
     2: optional string sub
 }
 
@@ -848,6 +848,8 @@ struct Sponsorship {
     4: required string sponsorLink
 
     5: optional SponsorshipTargeting targeting
+
+    6: optional string aboutLink
 }
 
 struct Tag {
@@ -955,6 +957,8 @@ struct Tag {
     * A list of all the active sponsorships running against this tag
     */
     18: optional list<Sponsorship> activeSponsorships
+
+    19: optional string paidContentType
 }
 
 struct Atoms {


### PR DESCRIPTION
Adds the new fields introduced in https://github.com/guardian/content-api/pull/1543 into the thrift model.