### PR TITLE
Add a new membership tiers for premium content

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -175,7 +175,8 @@ enum AssetType {
 
 enum MembershipTier {
     MEMBERS_ONLY = 0,
-    PAID_MEMBERS_ONLY = 1
+    PAID_MEMBERS_ONLY = 1,
+    PREMIUM_CONTENT = 2
 }
 
 enum SponsorshipType {


### PR DESCRIPTION
The new membership tiers is to take in account the existing premium mode which enable paid members on mobile apps top get access to premium content.

