### PR TITLE
Move events.thrift from Crier into content-api-models.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 /project/project/
+.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,11 @@ val mavenSettings = Seq(
         <name>Mariot Chauvin</name>
         <url>https://github.com/mchv</url>
       </developer>
+      <developer>
+        <id>LATaylor-guardian</id>
+        <name>Luke Taylor</name>
+        <url>https://github.com/LATaylor-guardian</url>
+      </developer>
     </developers>
   ),
   publishMavenStyle := true,

--- a/models/src/main/thrift/events/crier/event.thrift
+++ b/models/src/main/thrift/events/crier/event.thrift
@@ -1,0 +1,34 @@
+namespace scala com.gu.crier.model.event.v1
+
+include "content/v1.thrift"
+
+enum EventType {
+    Update = 1,
+    Delete = 2
+}
+
+enum ItemType {
+    Content = 1,
+    Tag = 2,
+    Section = 3,
+    StoryPackage = 4
+}
+
+union EventPayload {
+
+  1: v1.Content content
+
+}
+
+struct Event {
+
+    1: required string payloadId
+
+    2: required EventType eventType
+
+    3: required ItemType itemType
+
+    4: required i64 dateTime
+
+    5: optional EventPayload payload
+}


### PR DESCRIPTION
Most clients have to rely on this project anyway when using Crier so it makes sense for the events.thrift file to live in here also. This also prevents it from being copied and posted everywhere.