### PR TITLE
Expose the internal revision number field

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/Serialization.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/Serialization.scala
@@ -69,6 +69,7 @@ object Serialization {
     case JField("explicit", JString(s)) => JField("explicit", JBool(s.toBoolean))
     case JField("clean", JString(s)) => JField("clean", JBool(s.toBoolean))
     case JField("safeEmbedCode", JString(s)) => JField("safeEmbedCode", JBool(s.toBoolean))
+    case JField("internalRevision", JString(s)) => JField("internalRevision", JInt(s.toInt))
   }
 
   def thriftEnum2JString[A <: ThriftEnum](implicit classTag: ClassTag[A]): PartialFunction[Any, JString] = {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -806,6 +806,8 @@ struct ContentFields {
     37: optional bool sensitive
 
     38: optional string lang
+
+    39: optional i32 internalRevision
 }
 
 struct Reference {


### PR DESCRIPTION
This is needed by Crier and possibly other apps.