### PR TITLE
Add internal revision field to Crier's model

### DIFF
--- a/models/src/main/thrift/events/crier/event.thrift
+++ b/models/src/main/thrift/events/crier/event.thrift
@@ -36,6 +36,11 @@ struct RetrievableContent {
      * The timestamp for when that specific payload was last modified
      */
     3: optional i64 lastModifiedDate
+
+    /*
+     * The internal revision number of the replaced content payload
+     */
+    4: optional i32 internalRevision
 }
 
 union EventPayload {


### PR DESCRIPTION
I should've merged this before releasing the new model, oops. Sorry.