### PR TITLE
Make Rights fields required, default to false

### DIFF
--- a/json/src/test/scala/com/gu/contentapi/json/JsonParserItemTest.scala
+++ b/json/src/test/scala/com/gu/contentapi/json/JsonParserItemTest.scala
@@ -199,9 +199,9 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues {
 
   it should "parse content rights" in {
     val rights = contentItemResponse.content.get.rights.get
-    rights.syndicatable should be (Some(true))
-    rights.subscriptionDatabases should be (Some(true))
-    rights.developerCommunity should be (Some(true))
+    rights.syndicatable should be (true)
+    rights.subscriptionDatabases should be (true)
+    rights.developerCommunity should be (true)
   }
 
   "tag item parser" should "parse basic response fields" in {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -201,11 +201,11 @@ enum SponsorshipType {
 
 struct Rights {
 
-    1: optional bool syndicatable
+    1: optional bool syndicatable = false
 
-    2: optional bool subscriptionDatabases
+    2: optional bool subscriptionDatabases = false
 
-    3: optional bool developerCommunity
+    3: optional bool developerCommunity = false
 }
 
 struct AssetFields {


### PR DESCRIPTION
This was a breaking change introduced in preparation for thriftification, but we've decided it's not worth the pain