### PR TITLE
Improve deserialisation performance 

### DIFF
--- a/macros/src/main/scala/com/gu/contentapi/circe/CirceScroogeMacros.scala
+++ b/macros/src/main/scala/com/gu/contentapi/circe/CirceScroogeMacros.scala
@@ -109,7 +109,7 @@ object CirceScroogeMacros {
     _root_.io.circe.Decoder.instance((cursor: _root_.io.circe.HCursor) => {
       cursor.focus.asString match {
         case _root_.scala.Some(value) =>
-          val withoutHyphens = value.replaceAllLiterally("-", "")
+          val withoutHyphens = org.apache.commons.lang3.StringUtils.remove(value, '-')
           _root_.cats.data.Xor.right($valueOf(withoutHyphens).getOrElse($unknown.apply(-1)))
         case _ =>
           _root_.cats.data.Xor.left(_root_.io.circe.DecodingFailure($typeName, cursor.history))


### PR DESCRIPTION
Instead of using [slow regex pattern compilation](http://stackoverflow.com/questions/6262397/string-replaceall-is-considerably-slower-than-doing-the-job-yourself) each time we simply intend to remove all `-` char occurrences we use an implementation that iterates on the char sequence.

Using 
```
jmh:run -i 20 -wi 20 -f1 -t1 .*JsonDecodeBenchmark.*
```
Before:
```
[info] Benchmark                                        Mode  Cnt        Score        Error  Units
[info] JsonDecodeBenchmark.circe                        avgt   20   245473.327 ±  38121.982  ns/op
[info] JsonDecodeBenchmark.circeDeserializeEachContent  avgt   20  3594792.021 ± 504839.078  ns/op
```
After
```
[info] Benchmark                                        Mode  Cnt        Score       Error  Units
[info] JsonDecodeBenchmark.circe                        avgt   20   140887.359 ±  6593.934  ns/op
[info] JsonDecodeBenchmark.circeDeserializeEachContent  avgt   20  1892814.631 ± 47677.606  ns/op
```