### PR TITLE
Improve the Thrift struct Decoder macro to only use shapeless Lazy where necessary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,7 @@ lazy val json = Project(id = "content-api-models-json", base = file("json"))
   )
 
 lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
-  .dependsOn(json)
+  .dependsOn(json, scala)
   .settings(commonSettings)
   .enablePlugins(JmhPlugin)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,8 @@ lazy val macros = Project(id = "content-api-models-macros", base = file("macros"
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "org.apache.thrift" % "libthrift" % "0.9.1",
-      "com.twitter" %% "scrooge-core" % "4.5.0"
+      "com.twitter" %% "scrooge-core" % "4.5.0",
+      "org.apache.commons" % "commons-lang3" % "3.4"
     )
   )
 


### PR DESCRIPTION
This is because use of Lazy incurs a runtime cost. We should only use it when we need it to hack around implicit resolution problems in the compiler.

Before:

```
[info] Benchmark                                        Mode  Cnt        Score       Error  Units
[info] JsonDecodeBenchmark.circe                        avgt   40   104592.251 ±  4303.060  ns/op
[info] JsonDecodeBenchmark.circeDeserializeEachContent  avgt   40  1751011.694 ± 93215.817  ns/op
```

After:

```
[info] Benchmark                                        Mode  Cnt        Score       Error  Units
[info] JsonDecodeBenchmark.circe                        avgt   40    95609.173 ±  1740.968  ns/op
[info] JsonDecodeBenchmark.circeDeserializeEachContent  avgt   40  1344281.162 ± 47547.969  ns/op
```

Also

* Add a benchmark for a very large, heavily nested response
* Tweak dependencies