### PR TITLE
Upgrade atom library to latest version, add explainer atom

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.2"
+      "com.gu" % "content-atom-model-thrift" % "2.4.3"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "1.0.1"
+      "com.gu" % "content-atom-model-thrift" % "2.4.2"
     )
   )
 

--- a/json/src/main/scala/com/gu/contentapi/json/CirceSerialization.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceSerialization.scala
@@ -7,6 +7,7 @@ import com.gu.contentatom.thrift.atom.media.MediaAtom
 import com.gu.contentatom.thrift.atom.quiz.QuizAtom
 import com.gu.contentapi.circe.CirceScroogeMacros._
 import com.gu.contentapi.client.model.v1._
+import contentatom.explainer.ExplainerAtom
 import org.joda.time.format.ISODateTimeFormat
 import org.json4s.JValue
 
@@ -153,8 +154,9 @@ object CirceSerialization {
       for {
         quizzes <- getAtoms(c, AtomType.Quiz)
         media <- getAtoms(c, AtomType.Media)
+        explainers <- getAtoms(c, AtomType.Explainer)
       } yield {
-        Atoms(quizzes = quizzes, media = media)
+        Atoms(quizzes = quizzes, media = media, explainers = explainers)
       }
     }
 
@@ -174,6 +176,7 @@ object CirceSerialization {
       atomType match {
         case AtomType.Quiz => c.downField("data").get[QuizAtom]("quiz").map(json => AtomData.Quiz(json))
         case AtomType.Media => c.downField("data").get[MediaAtom]("media").map(json => AtomData.Media(json))
+        case AtomType.Explainer => c.downField("data").get[ExplainerAtom]("explainer").map(json => AtomData.Explainer(json))
         case _ => Xor.left(DecodingFailure("AtomData", c.history))
       }
     }
@@ -182,6 +185,7 @@ object CirceSerialization {
       atomType match {
         case AtomType.Quiz => Some("quizzes")
         case AtomType.Media => Some("media")
+        case AtomType.Explainer => Some("explainer")
         case _ => None
       }
     }

--- a/json/src/main/scala/com/gu/contentapi/json/CirceSerialization.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceSerialization.scala
@@ -5,9 +5,9 @@ import cats.data.Xor
 import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails}
 import com.gu.contentatom.thrift.atom.media.MediaAtom
 import com.gu.contentatom.thrift.atom.quiz.QuizAtom
+import com.gu.contentatom.thrift.atom.explainer.ExplainerAtom
 import com.gu.contentapi.circe.CirceScroogeMacros._
 import com.gu.contentapi.client.model.v1._
-import contentatom.explainer.ExplainerAtom
 import org.joda.time.format.ISODateTimeFormat
 import org.json4s.JValue
 
@@ -185,7 +185,7 @@ object CirceSerialization {
       atomType match {
         case AtomType.Quiz => Some("quizzes")
         case AtomType.Media => Some("media")
-        case AtomType.Explainer => Some("explainer")
+        case AtomType.Explainer => Some("explainers")
         case _ => None
       }
     }

--- a/json/src/main/scala/com/gu/contentapi/json/Serialization.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/Serialization.scala
@@ -8,8 +8,8 @@ import org.json4s.JsonAST.JValue
 import com.gu.storypackage.model.v1.{ArticleType, Group}
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.quiz._
-import com.gu.contentatom.thrift.atom.media.{MediaAtom, Platform, AssetType => MediaAtomAssetType}
-import contentatom.explainer.ExplainerAtom
+import com.gu.contentatom.thrift.atom.media.{MediaAtom, Platform, AssetType => MediaAtomAssetType, Category}
+import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
 
 import scala.PartialFunction._
 import scala.reflect.ClassTag
@@ -33,7 +33,9 @@ object Serialization {
     StoryPackageGroupSerializer +
     RemovePassthroughFieldsFromThriftStruct +
     MediaAtomAssetTypeSerializer +
-    PlatformTypeSerializer
+    PlatformTypeSerializer +
+    CategorySerializer +
+    DisplayTypeSerializer
 
   def destringifyFields: PartialFunction[JField, JField] = {
     case JField("summary", JString(s)) => JField("summary", JBool(s.toBoolean))
@@ -205,6 +207,20 @@ object Serialization {
       case JString(s) => MediaAtomAssetType.valueOf(s).getOrElse(MediaAtomAssetType.EnumUnknownAssetType(-1))
     },
     thriftEnum2JString[MediaAtomAssetType]
+    ))
+
+  object CategorySerializer extends CustomSerializer[Category](format => (
+    {
+      case JString(s) => Category.valueOf(s).getOrElse(Category.EnumUnknownCategory(-1))
+    },
+    thriftEnum2JString[Category]
+    ))
+
+  object DisplayTypeSerializer extends CustomSerializer[DisplayType](format => (
+    {
+      case JString(s) => DisplayType.valueOf(s).getOrElse(DisplayType.EnumUnknownDisplayType(-1))
+    },
+    thriftEnum2JString[DisplayType]
     ))
 
   object PlatformTypeSerializer extends CustomSerializer[Platform](format => (

--- a/json/src/main/scala/com/gu/contentapi/json/Serialization.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/Serialization.scala
@@ -1,7 +1,7 @@
 package com.gu.contentapi.json
 
 import com.gu.contentapi.client.model.v1._
-import com.twitter.scrooge.{ThriftStruct, ThriftEnum}
+import com.twitter.scrooge.{ThriftEnum, ThriftStruct}
 import org.joda.time.format.ISODateTimeFormat
 import org.json4s._
 import org.json4s.JsonAST.JValue
@@ -9,6 +9,7 @@ import com.gu.storypackage.model.v1.{ArticleType, Group}
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.quiz._
 import com.gu.contentatom.thrift.atom.media.{MediaAtom, Platform, AssetType => MediaAtomAssetType}
+import contentatom.explainer.ExplainerAtom
 
 import scala.PartialFunction._
 import scala.reflect.ClassTag
@@ -137,6 +138,7 @@ object Serialization {
       atomType match {
         case AtomType.Quiz => Some(AtomData.Quiz((atom \ "data" \ "quiz").extract[QuizAtom]))
         case AtomType.Media => Some(AtomData.Media((atom \ "data" \ "media").extract[MediaAtom]))
+        case AtomType.Explainer => Some(AtomData.Explainer((atom \ "data" \ "explainer").extract[ExplainerAtom]))
         case _ => None
       }
     }
@@ -145,6 +147,7 @@ object Serialization {
       atomType match {
         case AtomType.Quiz => Some("quizzes")
         case AtomType.Media => Some("media")
+        case AtomType.Explainer => Some("explainer")
         case _ => None
       }
     }
@@ -173,7 +176,8 @@ object Serialization {
   object DummyAtomObject
   object AtomsSerializer extends CustomSerializer[Atoms](format => (
     {
-      case rawAtoms: JObject => Atoms(quizzes = getAtoms(rawAtoms, AtomType.Quiz), media = getAtoms(rawAtoms, AtomType.Media))
+      case rawAtoms: JObject => Atoms(quizzes = getAtoms(rawAtoms, AtomType.Quiz), media = getAtoms(rawAtoms, AtomType.Media),
+        explainers = getAtoms(rawAtoms, AtomType.Explainer))
     },
     {
       PartialFunction.empty[Any, JValue]  //No custom serialization logic required for Atoms

--- a/json/src/main/scala/com/gu/contentapi/json/Serialization.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/Serialization.scala
@@ -149,7 +149,7 @@ object Serialization {
       atomType match {
         case AtomType.Quiz => Some("quizzes")
         case AtomType.Media => Some("media")
-        case AtomType.Explainer => Some("explainer")
+        case AtomType.Explainer => Some("explainers")
         case _ => None
       }
     }

--- a/json/src/test/resources/templates/content-with-atom-explainer.json
+++ b/json/src/test/resources/templates/content-with-atom-explainer.json
@@ -1,0 +1,48 @@
+{
+  "fields": {
+    "body": "<p>body</p>"
+  },
+  "apiUrl": "http://content.code.dev-guardianapis.com/test/2016/jan/12/example",
+  "webUrl": "http://www.code.dev-theguardian.com/test/2016/jan/12/example",
+  "webPublicationDate": "2016-01-12T15:17:19Z",
+  "webTitle": "example",
+  "sectionId": "test",
+  "type": "article",
+  "id": "test/2016/jan/12/example",
+  "isHosted": false,
+  "atoms": {
+    "quizzes": [],
+    "media": [],
+    "explainers": [{
+      "id" : "explainer-atom-id",
+      "atomType" : "explainer",
+      "labels" : [ ],
+      "defaultHtml" : "<div</div>\n",
+      "data" : {
+        "explainer": {
+          "title": "Who is Harry Potter?",
+          "body": "<p>A great wizard!</p>",
+          "displayType": "expandable"
+        }
+      },
+      "contentChangeDetails" : {
+        "lastModified" : {
+          "date" : 1449058181000,
+          "user" : {
+            "email" : "chris.finch@guardian.co.uk"
+          }
+        },
+        "created" : {
+          "date" : 1449058105000,
+          "user" : {
+            "email" : "chris.finch@guardian.co.uk"
+          }
+        },
+        "revision" : 1
+      }
+    }]
+  },
+  "sectionName": "Test",
+  "references": [],
+  "tags": []
+}

--- a/json/src/test/resources/templates/content-with-atom-media.json
+++ b/json/src/test/resources/templates/content-with-atom-media.json
@@ -28,7 +28,9 @@
             }
           ],
           "activeVersion": 0,
-          "plutoProjectId": "pluto_id"
+          "plutoProjectId": "pluto_id",
+          "category": "documentary",
+          "title": "March of the penguins"
         }
       },
       "contentChangeDetails" : {
@@ -46,7 +48,8 @@
         },
         "revision" : 1
       }
-    }]
+    }],
+    "explainers": []
   },
   "sectionName": "Test",
   "references": [],

--- a/json/src/test/resources/templates/item-content-with-atom-explainer.json
+++ b/json/src/test/resources/templates/item-content-with-atom-explainer.json
@@ -17,25 +17,17 @@
       "isHosted": false,
       "atoms": {
         "quizzes": [],
-        "media": [{
-          "id" : "media-atom-id",
-          "atomType" : "media",
+        "media": [],
+        "explainers": [{
+          "id" : "explainer-atom-id",
+          "atomType" : "explainer",
           "labels" : [ ],
           "defaultHtml" : "<div</div>\n",
           "data" : {
-            "media": {
-              "assets": [
-                {
-                  "assetType": "video",
-                  "version": 0,
-                  "id": "a_video_atom",
-                  "platform": "youtube"
-                }
-              ],
-              "activeVersion": 0,
-              "plutoProjectId": "pluto_id",
-              "category": "documentary",
-              "title": "March of the penguins"
+            "explainer": {
+              "title": "Who is Harry Potter?",
+              "body": "<p>A great wizard!</p>",
+              "displayType": "expandable"
             }
           },
           "contentChangeDetails" : {
@@ -53,8 +45,7 @@
             },
             "revision" : 1
           }
-        }],
-        "explainers": []
+        }]
       },
       "sectionName": "Test",
       "references": [],

--- a/json/src/test/resources/templates/item-content-with-atom-explainer.json
+++ b/json/src/test/resources/templates/item-content-with-atom-explainer.json
@@ -1,0 +1,64 @@
+{
+  "response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 1,
+    "content": {
+      "fields": {
+        "body": "<p>body</p>"
+      },
+      "apiUrl": "http://content.code.dev-guardianapis.com/test/2016/jan/12/example",
+      "webUrl": "http://www.code.dev-theguardian.com/test/2016/jan/12/example",
+      "webPublicationDate": "2016-01-12T15:17:19Z",
+      "webTitle": "example",
+      "sectionId": "test",
+      "type": "article",
+      "id": "test/2016/jan/12/example",
+      "isHosted": false,
+      "atoms": {
+        "quizzes": [],
+        "media": [{
+          "id" : "media-atom-id",
+          "atomType" : "media",
+          "labels" : [ ],
+          "defaultHtml" : "<div</div>\n",
+          "data" : {
+            "media": {
+              "assets": [
+                {
+                  "assetType": "video",
+                  "version": 0,
+                  "id": "a_video_atom",
+                  "platform": "youtube"
+                }
+              ],
+              "activeVersion": 0,
+              "plutoProjectId": "pluto_id",
+              "category": "documentary",
+              "title": "March of the penguins"
+            }
+          },
+          "contentChangeDetails" : {
+            "lastModified" : {
+              "date" : 1449058181000,
+              "user" : {
+                "email" : "chris.finch@guardian.co.uk"
+              }
+            },
+            "created" : {
+              "date" : 1449058105000,
+              "user" : {
+                "email" : "chris.finch@guardian.co.uk"
+              }
+            },
+            "revision" : 1
+          }
+        }],
+        "explainers": []
+      },
+      "sectionName": "Test",
+      "references": [],
+      "tags": []
+    }
+  }
+}

--- a/json/src/test/resources/templates/item-content-with-atom-media.json
+++ b/json/src/test/resources/templates/item-content-with-atom-media.json
@@ -33,7 +33,9 @@
                 }
               ],
               "activeVersion": 0,
-              "plutoProjectId": "pluto_id"
+              "plutoProjectId": "pluto_id",
+              "category": "documentary",
+              "title": "March of the penguins"
             }
           },
           "contentChangeDetails" : {
@@ -51,7 +53,8 @@
             },
             "revision" : 1
           }
-        }]
+        }],
+        "explainers": []
       },
       "sectionName": "Test",
       "references": [],

--- a/json/src/test/resources/templates/item-content-with-atom-quiz.json
+++ b/json/src/test/resources/templates/item-content-with-atom-quiz.json
@@ -72,7 +72,8 @@
             }
           }
         ],
-        "media": []
+        "media": [],
+        "explainers": []
       },
       "sectionName": "Test",
       "references": [],

--- a/json/src/test/scala/com/gu/contentapi/json/CirceSpec.scala
+++ b/json/src/test/scala/com/gu/contentapi/json/CirceSpec.scala
@@ -80,6 +80,10 @@ class CirceSpec extends FlatSpec with Matchers {
     compareAgainstJson4s[Content]("content-with-atom-media.json")
   }
 
+  it should "deserialize a Content (including an explainer atom) with the same result as json4s" in {
+    compareAgainstJson4s[Content]("content-with-atom-explainer.json")
+  }
+
   it should "deserialize a Content (including blocks) with the same result as json4s" in {
     compareAgainstJson4s[Content]("content-with-blocks.json")
   }

--- a/json/src/test/scala/com/gu/contentapi/json/SerializationSpec.scala
+++ b/json/src/test/scala/com/gu/contentapi/json/SerializationSpec.scala
@@ -99,6 +99,10 @@ class SerializationSpec extends FlatSpec with Matchers {
     checkRoundTrip[ItemResponse]("item-content-with-atom-media.json")
   }
 
+  it should "round-trip an ItemResponse with an explainer atom" in {
+    checkRoundTrip[ItemResponse]("item-content-with-atom-explainer.json")
+  }
+
   it should "round-trip an ItemResponse with blocks" in {
     checkRoundTrip[ItemResponse]("item-content-with-blocks.json")
   }

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1234,6 +1234,8 @@ struct Atoms {
     2: optional list<contentatom.Atom> viewpoints
 
     3: optional list<contentatom.Atom> media
+
+    4: optional list<contentatom.Atom> explainers
 }
 
 struct ContentStats {
@@ -1587,6 +1589,8 @@ struct ItemResponse {
     21: optional list<contentatom.Atom> viewpoints
 
     22: optional contentatom.Atom media
+
+    23: optional contentatom.Atom explainer
 }
 
 struct TagsResponse {


### PR DESCRIPTION
This change allows explainer atoms to be fetched by concierge. I've tested it by doing publish-local and using in my local concierge.
