### PR TITLE
Simplify the macro-generated Decoder for ThriftEnum

### DIFF
--- a/macros/src/main/scala/com/gu/contentapi/circe/CirceScroogeMacros.scala
+++ b/macros/src/main/scala/com/gu/contentapi/circe/CirceScroogeMacros.scala
@@ -128,14 +128,9 @@ object CirceScroogeMacros {
     val unknown = A.companion.member(TermName(s"EnumUnknown$typeName"))
 
     q"""
-    _root_.io.circe.Decoder.instance((cursor: _root_.io.circe.HCursor) => {
-      cursor.focus.asString match {
-        case _root_.scala.Some(value) =>
-          val withoutHyphens = _root_.org.apache.commons.lang3.StringUtils.remove(value, '-')
-          _root_.cats.data.Xor.right($valueOf(withoutHyphens).getOrElse($unknown.apply(-1)))
-        case _ =>
-          _root_.cats.data.Xor.left(_root_.io.circe.DecodingFailure($typeName, cursor.history))
-      }
+    _root_.io.circe.Decoder[String].map(value => {
+      val withoutHyphens = _root_.org.apache.commons.lang3.StringUtils.remove(value, '-')
+      $valueOf(withoutHyphens).getOrElse($unknown.apply(-1))
     })
     """
   }


### PR DESCRIPTION
We piggyback on the builtin Decoder for String to write the same thing in a slightly less verbose way.