### PR TITLE
add cta to item response

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1601,6 +1601,8 @@ struct ItemResponse {
     22: optional contentatom.Atom media
 
     23: optional contentatom.Atom explainer
+
+    24: optional contentatom.Atom cta
 }
 
 struct TagsResponse {


### PR DESCRIPTION
for accessing individual cta atoms via the `atom/cta/<id>` endpoint