### PR TITLE
Update of the thrift definition to support sponsorship logo dimensions

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1037,6 +1037,14 @@ struct SponsorshipTargeting {
     2: optional list<string> validEditions
 }
 
+struct SponsorshipLogoDimensions {
+
+    1: required i32 width
+
+    2: required i32 height
+
+}
+
 struct Sponsorship {
 
     1: required SponsorshipType sponsorshipType
@@ -1050,6 +1058,9 @@ struct Sponsorship {
     5: optional SponsorshipTargeting targeting
 
     6: optional string aboutLink
+
+    7: optional SponsorshipLogoDimensions sponsorLogoDimensions
+
 }
 
 struct Tag {


### PR DESCRIPTION
This change updates the thrift definition to support sponsorship logo dimensions.

It comes after 
1. https://github.com/guardian/content-api/pull/1711 , and 
2. https://github.com/guardian/content-api/pull/1714

The dimensions are published by the tag manager here: https://github.com/guardian/tags-thrift-schema/blob/master/src/main/thrift/image.thrift