### PR TITLE
Add bodyText and charCount fields

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -998,6 +998,10 @@ struct ContentFields {
     43: optional string shortSocialShareText
 
     44: optional string socialShareText
+
+    45: optional string bodyText
+
+    46: optional i32 charCount
 }
 
 struct Reference {


### PR DESCRIPTION
This is for alexa (but possibly other apps later).
The `bodyText` does not contain any tags. The `charCount` is the number of chars in `bodyText`, and will allow us to exclude long articles.