### PR TITLE
add field for vidispineid

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1003,7 +1003,7 @@ struct ContentFields {
 
     46: optional i32 charCount
 
-    47: optional string internalVideoId
+    47: optional string internalVideoCode
 }
 
 struct Reference {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1002,6 +1002,8 @@ struct ContentFields {
     45: optional string bodyText
 
     46: optional i32 charCount
+
+    47: optional string internalVideoId
 }
 
 struct Reference {


### PR DESCRIPTION
We would like to keep track of the vidispineId so that we can track back from a video page that was created by pluto, to that entry in pluto.

This PR is the first step. There will also be changes to composer and porter to actuall fill this field in.