### PR TITLE
Add Content Atom Type and ID Data to atom elements

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -651,6 +651,13 @@ struct VineElementFields {
 
 }
 
+struct ContentAtomElementFields {
+
+  1: required string atomId
+
+  2: required string atomType
+
+}
 
 
 struct BlockElement {
@@ -692,6 +699,8 @@ struct BlockElement {
     18: optional CommentElementFields commentTypeData
 
     19: optional VineElementFields vineTypeData
+
+    20: optional ContentAtomElementFields contentAtomTypeData
 
 }
 


### PR DESCRIPTION
This adds more information about content atom elements at a block level.
Adding 2 fields for content atom elements:
- Atom ID
- Atom Type

Changes discussed with @clloyd and @mchv 