### PR TITLE
Bump content-atom to 2.4.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.13"
+      "com.gu" % "content-atom-model-thrift" % "2.4.15"
     )
   )
 


### PR DESCRIPTION
- include legallySensitive flag for atoms (2.4.14)
- make currency value an int (2.4.15)