### PR TITLE
Thrift union macros

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -1,19 +1,11 @@
 package com.gu.contentapi.json
 
 import com.gu.contentapi.client.model.v1._
-import com.twitter.scrooge.{ThriftEnum, ThriftStruct}
+import com.twitter.scrooge.ThriftEnum
 import io.circe._
 import io.circe.syntax._
 import com.gu.contentapi.circe.CirceScroogeMacros._
-import com.gu.contentatom.thrift.atom.explainer.ExplainerAtom
-import com.gu.contentatom.thrift.atom.media.MediaAtom
-import com.gu.contentatom.thrift.atom.quiz.QuizAtom
-import com.gu.contentatom.thrift.atom.cta.CTAAtom
-import com.gu.contentatom.thrift.atom.interactive.InteractiveAtom
-import com.gu.contentatom.thrift.atom.review.ReviewAtom
-import com.gu.contentatom.thrift.atom.recipe.RecipeAtom
 import com.gu.contentatom.thrift.{Atom, AtomData}
-import io.circe.generic.auto._
 import org.joda.time.format.ISODateTimeFormat
 
 object CirceEncoders {
@@ -65,7 +57,8 @@ object CirceEncoders {
   implicit val contentStatsEncoder = Encoder[ContentStats]
   implicit val sectionEncoder = Encoder[Section]
   implicit val debugEncoder = Encoder[Debug]
-  implicit val atomEncoder = AtomEncoder.genAtomEncoder
+  implicit val atomDataEncoder = Encoder[AtomData]
+  implicit val atomEncoder = Encoder[Atom]
   implicit val atomsEncoder = Encoder[Atoms]
   implicit val contentEncoder = Encoder[Content]
   implicit val mostViewedVideoEncoder = Encoder[MostViewedVideo]
@@ -87,37 +80,4 @@ object CirceEncoders {
     // We don't include millis in JSON, for backwards-compatibility
     Json.fromString(dateTime.toString(ISODateTimeFormat.dateTimeNoMillis()))
   }
-
-  /**
-    * TODO - I *will* write a pair of macros for encoding/decoding thrift union types, then delete all this stuff.
-   */
-  object AtomEncoder {
-
-    def genAtomEncoder: Encoder[Atom] = Encoder.instance[Atom] { atom =>
-      Json.fromFields(List(
-        "data" -> Json.fromFields(List(
-          atom.atomType.name.toLowerCase -> getAtomData(atom.data)
-        )),
-        "contentChangeDetails" -> atom.contentChangeDetails.asJson,
-        "atomType" -> atom.atomType.asJson,
-        "id" -> atom.id.asJson,
-        "labels" -> atom.labels.asJson,
-        "defaultHtml" -> atom.defaultHtml.asJson
-      ))
-    }
-
-    private def getAtomData(data: AtomData): Json = {
-      data match {
-        case AtomData.Quiz(quiz) => quiz.asJson(Encoder[QuizAtom])
-        case AtomData.Media(media) => media.asJson(Encoder[MediaAtom])
-        case AtomData.Explainer(explainer) => explainer.asJson(Encoder[ExplainerAtom])
-        case AtomData.Cta(cta) => cta.asJson(Encoder[CTAAtom])
-        case AtomData.Interactive(interactive) => interactive.asJson(Encoder[InteractiveAtom])
-        case AtomData.Review(review) => review.asJson(Encoder[ReviewAtom])
-        case AtomData.Recipe(recipe) => recipe.asJson(Encoder[RecipeAtom])
-        case _ => Json.Null
-      }
-    }
-  }
-
 }

--- a/macros/src/main/scala/com/gu/contentapi/circe/CirceScroogeMacros.scala
+++ b/macros/src/main/scala/com/gu/contentapi/circe/CirceScroogeMacros.scala
@@ -2,9 +2,9 @@ package com.gu.contentapi.circe
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
-import com.twitter.scrooge.{ThriftEnum, ThriftStruct}
+import com.twitter.scrooge.{ThriftEnum, ThriftStruct, ThriftUnion}
 import io.circe.{Decoder, Encoder}
-import shapeless.Lazy
+import shapeless.{Lazy, |¬|}
 
 /**
   * Macros for Circe deserialization of various Scrooge-generated classes.
@@ -40,16 +40,19 @@ object CirceScroogeMacros {
     * }
     * }}}
     */
-  implicit def decodeThriftStruct[A <: ThriftStruct]: Decoder[A] = macro decodeThriftStruct_impl[A]
+  type NotUnion[T] = |¬|[ThriftUnion]#λ[T]  //Tell compiler not to use this Decoder for Unions
+  implicit def decodeThriftStruct[A <: ThriftStruct : NotUnion]: Decoder[A] = macro decodeThriftStruct_impl[A]
 
-  def decodeThriftStruct_impl[A: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
+  def decodeThriftStruct_impl[A: c.WeakTypeTag](c: blackbox.Context)(x: c.Tree): c.Tree = {
     import c.universe._
 
     val A = weakTypeOf[A]
+
     val apply = A.companion.member(TermName("apply")) match {
       case symbol if symbol.isMethod && symbol.asMethod.paramLists.size == 1 => symbol.asMethod
       case _ => c.abort(c.enclosingPosition, "Not a valid Scrooge class: could not find the companion object's apply method")
     }
+
     val params = apply.paramLists.head.zipWithIndex.map { case (param, i) =>
       val name = param.name
       val tpe = param.typeSignature
@@ -110,7 +113,6 @@ object CirceScroogeMacros {
     val tree = q"""{
       _root_.io.circe.Decoder.instance((cursor: _root_.io.circe.HCursor) => for (..${params.map(_._2)}) yield $apply(..${params.map(_._1)}))
     }"""
-    //println(showCode(tree))
     tree
   }
 
@@ -134,6 +136,97 @@ object CirceScroogeMacros {
     })
     """
   }
+
+  /**
+    * Macro to produce Decoders for ThriftUnion types.
+    *
+    * A ThriftUnion, U, has a companion object which defines a case class extending U for each member of the union.
+    * Each case class takes a single parameter, which is a type alias for the actual ThriftStruct contained by that member.
+    *
+    * E.g. for the following thrift definition:
+    * {{{
+    *   union U {
+    *     1: FooStruct foo
+    *     2: BarStruct bar
+    *   }
+    *
+    *   struct T {
+    *     1: U union
+    *   }
+    * }}}
+    *
+    * We may expect the following JSON:
+    * {{{
+    *   {
+    *     union: {
+    *       foo: {
+    *         ...
+    *       }
+    *     }
+    *   }
+    * }}}
+    *
+    * In the scrooge-generated code, for the member foo of union U, there exists a case class:
+    *   {{{
+    *   case class Foo(foo: FooAlias) extends U
+    *   }}}
+    * where FooAlias aliases FooStruct.
+    * We need to match on the single JSON field and determine which member of the union is present.
+    * So the decoder will contain a case statement for the member foo as follows:
+    *   {{{
+    *   case "foo" => c.cursor.downField("foo").flatMap(_.as[FooStruct](decoderForFooStruct).toOption).map(Foo)
+    *   }}}
+    *
+    */
+  implicit def decodeThriftUnion[A <: ThriftUnion]: Decoder[A] = macro decodeThriftUnion_impl[A]
+
+  def decodeThriftUnion_impl[A: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
+    import c.universe._
+
+    val A = weakTypeOf[A]
+
+    val memberClasses: Iterable[Symbol] = A.companion.members.filter { member =>
+      if (member.isClass && member.name.toString != "UnknownUnionField") {
+        member.asClass.baseClasses.contains(A.typeSymbol)
+      } else false
+    }
+
+    val decoderCases: Iterable[Tree] = memberClasses.map { memberClass =>
+      val applyMethod = memberClass.typeSignature.companion.member(TermName("apply")) match {
+        case symbol if symbol.isMethod && symbol.asMethod.paramLists.size == 1 => symbol.asMethod
+        case _ => c.abort(c.enclosingPosition, s"Not a valid union class: could not find the member class' apply method (${A.typeSymbol.fullName})")
+      }
+
+      val param: Symbol = applyMethod.paramLists.headOption.flatMap(_.headOption).getOrElse(c.abort(c.enclosingPosition, s"Not a valid union class: could not find the member class' parameter (${A.typeSymbol.fullName})"))
+      val paramType = param.typeSignature.dealias
+      val paramName = param.name.toString
+
+      val decoderForParamType = appliedType(weakTypeOf[Decoder[_]].typeConstructor, paramType)
+      val implicitDecoderForParam: c.Tree = {
+        val normalImplicitDecoder = c.inferImplicitValue(decoderForParamType)
+        if (normalImplicitDecoder.nonEmpty) {
+          normalImplicitDecoder
+        } else {
+          val lazyDecoderForType = appliedType(weakTypeOf[Lazy[_]].typeConstructor, decoderForParamType)
+          val implicitLazyDecoder = c.inferImplicitValue(lazyDecoderForType)
+          if (implicitLazyDecoder.isEmpty) c.abort(c.enclosingPosition, s"Could not find an implicit Decoder[$paramType] even after resorting to Lazy")
+          q"_root_.scala.Predef.implicitly[_root_.shapeless.Lazy[_root_.io.circe.Decoder[$paramType]]].value"
+        }
+      }
+
+      cq"""$paramName => c.cursor.downField($paramName).flatMap(_.as[$paramType]($implicitDecoderForParam).toOption).map($applyMethod)"""
+    }
+
+    q"""{
+      _root_.io.circe.Decoder.instance {(c: _root_.io.circe.HCursor) =>
+        val result = c.cursor.fields.getOrElse(Nil).headOption.flatMap {
+          case ..$decoderCases
+        }
+        Xor.fromOption(result, ifNone = DecodingFailure(${A.typeSymbol.fullName}, c.history))
+      }
+    }"""
+  }
+
 
   implicit def encodeThriftStruct[A <: ThriftStruct]: Encoder[A] = macro encodeThriftStruct_impl[A]
 


### PR DESCRIPTION
This library currently has a custom decoder and encoder for `Atom`, because `AtomData` is a thrift union type and our standard macros cannot handle unions. This is annoying because we have to update this code every time an atom is added to the model.

This change adds macros for generating decoders and encoders for scrooge's thrift union types, meaning fewer code changes in future.