### PR TITLE
Bump content-atom-model to 2.4.23

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.20",
+      "com.gu" % "content-atom-model-thrift" % "2.4.23",
       "com.gu" % "content-entity-thrift" % "0.1.0"
     )
   )


### PR DESCRIPTION
New content-atom-model version with [fixed type for `year` field](https://github.com/guardian/content-atom/pull/69)

I have not introduced cross-compiling for scala 2.12 because it is incompatible with the currently-used version of circe, and upgrading to circe 0.6 will require some code changes.