### PR TITLE
Bump content-atom-model to 2.4.26

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.23",
+      "com.gu" % "content-atom-model-thrift" % "2.4.26",
       "com.gu" % "content-entity-thrift" % "0.1.0"
     )
   )


### PR DESCRIPTION
To make review `genre` field a list - https://github.com/guardian/content-atom/pull/70