### PR TITLE
Bumping the version of content-atom-model to 2.4.28

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.27",
+      "com.gu" % "content-atom-model-thrift" % "2.4.28",
       "com.gu" % "content-entity-thrift" % "0.1.0"
     )
   )


### PR DESCRIPTION
See [atom related changes](https://github.com/guardian/content-atom/pull/75)