### PR TITLE
Fix the format of revisionSeenByPorter

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1361,7 +1361,7 @@ struct Debug {
 
     1: optional CapiDateTime lastSeenByPorterAt
 
-    2: optional CapiDateTime revisionSeenByPorter
+    2: optional i64 revisionSeenByPorter
 
     3: optional string contentSource
 }


### PR DESCRIPTION
I think it will not break anyome
Current display is wrong:
```json
"debug": {
    "lastSeenByPorterAt": "2017-01-10T12:01:58Z",
    "revisionSeenByPorter": "0145-01-01T00:00:00Z",
    "contentSource": "flexible"
},
```