### PR TITLE
Bump content-atom dependency to 2.4.32.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.31",
+      "com.gu" % "content-atom-model-thrift" % "2.4.32",
       "com.gu" % "content-entity-thrift" % "0.1.3"
     )
   )


### PR DESCRIPTION
- Includes models for story questions atom.