### PR TITLE
Add categories field to Tag model

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1195,6 +1195,16 @@ struct Tag {
     21: optional string rcsId
 
     22: optional string r2ContributorId
+
+    /*
+     * A set of schema.org types, e.g. "Person", "Place"
+     */
+    23: optional set<string> tagCategories
+
+    /*
+     * A set of Guardian Entity IDs associated with this Tag
+     */
+    24: optional set<string> entityIds
 }
 
 struct Edition {


### PR DESCRIPTION
`categories` - these will correspond to the [google knowledge graph entity types](https://developers.google.com/knowledge-graph/)

The [model in tag manager](https://github.com/guardian/tagmanager/blob/master/app/model/Tag.scala#L27) already has an (unused) `categories` field.

`entityIds` - these will be any associated [entities](https://github.com/guardian/content-entity/pull/6)