### PR TITLE
Fezziwig 0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val json = Project(id = "content-api-models-json", base = file("json"))
   .settings(
     description := "Json parser for the Guardian's Content API models",
     libraryDependencies ++= Seq(
-      "com.gu" %% "fezziwig" % "0.2",
+      "com.gu" %% "fezziwig" % "0.3",
       "joda-time" % "joda-time" % "2.3",
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -1,11 +1,12 @@
 package com.gu.contentapi.json
 
 import io.circe._
-import com.gu.contentatom.thrift.{Atom, AtomData}
+import com.gu.contentatom.thrift.{Atom, AtomData, AtomType}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, decodeThriftUnion}
 import com.gu.contentapi.client.model.v1._
 import org.joda.time.format.ISODateTimeFormat
 import cats.syntax.either._
+import com.gu.storypackage.model.v1.Article
 
 object CirceDecoders {
 
@@ -49,6 +50,7 @@ object CirceDecoders {
   implicit val assetDecoder = Decoder[Asset]
   implicit val elementDecoder = Decoder[Element]
   implicit val referenceDecoder = Decoder[Reference]
+  implicit val blockElementDecoder = Decoder[BlockElement]
   implicit val blockDecoder = Decoder[Block]
   implicit val blocksDecoder = genBlocksDecoder
   implicit val rightsDecoder = Decoder[Rights]
@@ -57,9 +59,15 @@ object CirceDecoders {
   implicit val contentStatsDecoder = Decoder[ContentStats]
   implicit val sectionDecoder = Decoder[Section]
   implicit val debugDecoder = Decoder[Debug]
+  implicit val atomTypeDecoder = Decoder[AtomType]
+  implicit val atomDataDecoder = Decoder[AtomData]
+  implicit val atomDecoder = Decoder[Atom]
+  implicit val atomsDecoder = Decoder[Atoms]
   implicit val contentDecoder = Decoder[Content]
   implicit val mostViewedVideoDecoder = Decoder[MostViewedVideo]
   implicit val networkFrontDecoder = Decoder[NetworkFront]
+  implicit val articleDecoder = Decoder[Article]
+  implicit val packageArticleDecoder = Decoder[PackageArticle]
   implicit val packageDecoder = Decoder[Package]
   implicit val itemResponseDecoder = Decoder[ItemResponse]
   implicit val searchResponseDecoder = Decoder[SearchResponse]
@@ -72,10 +80,6 @@ object CirceDecoders {
   implicit val videoStatsResponseDecoder = Decoder[VideoStatsResponse]
   implicit val atomsUsageResponseDecoder = Decoder[AtomUsageResponse]
   implicit val removedContentResponseDecoder = Decoder[RemovedContentResponse]
-
-  implicit val atomDataDecoder = Decoder[AtomData]  //ThriftUnion
-  implicit val atomDecoder = Decoder[Atom]
-  implicit val atomsDecoder = Decoder[Atoms]
 
   // These two need to be written manually. I think the `Map[K, V]` type having 2 type params causes implicit divergence,
   // although shapeless's Lazy is supposed to work around that.


### PR DESCRIPTION
This version supports [accumulated errors](https://github.com/guardian/fezziwig/pull/11), which content-api-models will not use, but it's good to keep it up to date.

I've rearranged some of the implicit decoder definitions as this improves compilation times. 
E.g. if `Atom` is used in multiple places and we generate the decoder for `Atom` first, then that generated implicit definition can be used rather than generating a new decoder each time.

Benchmarks are fine.