### PR TITLE
adds reader revenue field

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1024,6 +1024,8 @@ struct ContentFields {
     46: optional i32 charCount
 
     47: optional string internalVideoCode
+
+    48: optional bool shouldHideReaderRevenue
 }
 
 struct Reference {


### PR DESCRIPTION
Adds fields optional field `shouldHideReaderRevenue`

See flexible changes [here](https://github.com/guardian/flexible-model/pull/3). 