### PR TITLE
content-atom-model 2.4.41

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.39",
+      "com.gu" % "content-atom-model-thrift" % "2.4.41",
       "com.gu" % "content-entity-thrift" % "0.1.5",
       "com.gu" % "story-model-thrift" % "1.1"
     )


### PR DESCRIPTION
https://github.com/guardian/content-atom/pull/92