### PR TITLE
Fezziwig 0.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,13 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.9.1",
       "com.twitter" %% "scrooge-core" % "4.5.0"
-    )
+    ),
+
+    /**
+      * WARNING - upgrading the following will break clients
+      */
+    dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1",
+    dependencyOverrides += "com.twitter" %% "scrooge-core" % "4.5.0"
   )
 
 /**
@@ -129,7 +135,7 @@ lazy val json = Project(id = "content-api-models-json", base = file("json"))
   .settings(
     description := "Json parser for the Guardian's Content API models",
     libraryDependencies ++= Seq(
-      "com.gu" %% "fezziwig" % "0.2",
+      "com.gu" %% "fezziwig" % "0.4",
       "joda-time" % "joda-time" % "2.3",
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
This picks up 2 changes, neither of which content-api-models needs:
1. Supports [accumulated errors](https://github.com/guardian/fezziwig/pull/11)
2. Newer versions of circe and thrift/scrooge - https://github.com/guardian/fezziwig/pull/12/files

### Decoder definitions
I've rearranged some of the implicit decoder definitions as this improves compilation times.

### dateTimeDecoder
A concierge test fails without this new `dateTimeDecoder`.
This has led to the discovery that dateTime fields under `requestedBodyBlocks` are being incorrectly serialized to json as objects rather than strings. It's not clear why this is happening - I'll fix it separately.

It's also not clear why bumping the fezziwig version has broken decoding of this json back to thrift. It was somehow working before - even though the old `dateTimeDecoder` was telling it to expect a string only.

### thrift/scrooge dependencies
We have to be careful not to use the latest version, as this has caused problems for clients. Hence the `dependencyOverrides`.