### PR TITLE
Add field to the thrift model

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1397,6 +1397,8 @@ struct Debug {
     2: optional i64 revisionSeenByPorter
 
     3: optional string contentSource
+
+    4: optional string originatingSystem
 }
 
 struct Content {


### PR DESCRIPTION
- Add "originatingSystem" field to the thrift model

This change is part of the process to add an "originatingSystem" field from flex to capi. This field will be used by the Tools team for metrics purposes.

Porter changes pr [here](https://github.com/guardian/content-api/pull/1987)
Flexible Model pr [here](https://github.com/guardian/flexible-model/pull/8)
Elastic Search pr [here](https://github.com/guardian/content-api/pull/1985)