### PR TITLE
Upgrade to scala 2.12.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,11 @@ val mavenSettings = Seq(
         <name>Regis Kuckaertz</name>
         <url>https://github.com/regiskuckaertz</url>
       </developer>
+      <developer>
+        <id>annebyrne</id>
+        <name>Anne Byrne</name>
+        <url>https://github.com/annebyrne</url>
+      </developer>
     </developers>
   ),
   publishMavenStyle := true,
@@ -40,14 +45,14 @@ val mavenSettings = Seq(
 )
 
 val commonSettings = Seq(
-  scalaVersion := "2.11.8",
-  crossPaths := false,
+  scalaVersion := "2.12.3",
+  crossScalaVersions := Seq("2.11.8", scalaVersion.value),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   organization := "com.gu",
   licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 ) ++ mavenSettings
 
-val circeVersion = "0.7.0"
+val circeVersion = "0.8.0"
 
 /**
   * Root project
@@ -116,14 +121,13 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
     },
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.9.1",
-      "com.twitter" %% "scrooge-core" % "4.5.0"
+      "com.twitter" %% "scrooge-core" % "4.18.0"
     ),
 
     /**
       * WARNING - upgrading the following will break clients
       */
-    dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1",
-    dependencyOverrides += "com.twitter" %% "scrooge-core" % "4.5.0"
+    dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
   )
 
 /**
@@ -135,14 +139,14 @@ lazy val json = Project(id = "content-api-models-json", base = file("json"))
   .settings(
     description := "Json parser for the Guardian's Content API models",
     libraryDependencies ++= Seq(
-      "com.gu" %% "fezziwig" % "0.4",
+      "com.gu" %% "fezziwig" % "0.6",
       "joda-time" % "joda-time" % "2.3",
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-optics" % circeVersion,
-      "com.github.agourlay" %% "cornichon" % "0.9.1" % "test",
-      "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+      "org.gnieh" %% "diffson-circe" % "2.2.2" % "test",
+      "org.scalatest" %% "scalatest" % "3.0.1" % "test",
       "com.google.guava" % "guava" % "19.0" % "test"
     ),
     mappings in (Compile, packageDoc) := Nil

--- a/json/src/test/scala/com/gu/contentapi/json/CirceRoundTripSpec.scala
+++ b/json/src/test/scala/com/gu/contentapi/json/CirceRoundTripSpec.scala
@@ -1,6 +1,5 @@
 package com.gu.contentapi.json
 
-import com.github.agourlay.cornichon.json.JsonDiff.Diff
 import com.gu.contentapi.client.model.v1._
 import com.gu.contentapi.json.utils.JsonHelpers._
 import io.circe.{Decoder, Encoder, Json}
@@ -12,7 +11,7 @@ import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct,
 import com.gu.contentapi.json.CirceEncoders._
 import com.gu.contentapi.json.CirceDecoders._
 import cats.syntax.either._
-
+import gnieh.diffson.circe._
 
 class CirceRoundTripSpec extends FlatSpec with Matchers {
 
@@ -167,22 +166,9 @@ class CirceRoundTripSpec extends FlatSpec with Matchers {
     jsons.foreach(j => checkDiff(j._1, j._2))
   }
 
-  val Identical = Diff(Json.Null, Json.Null, Json.Null)
   def checkDiff(jsonBefore: Json, jsonAfter: Json) = {
-    import com.github.agourlay.cornichon.json.JsonDiff.{ diff, Diff }
-    val d: Diff = diff(jsonBefore, jsonAfter)
-
-    if (d != Identical) {
-      println("JSON before:")
-      println(jsonBefore.spaces2)
-      println("=====")
-      println("JSON after:")
-      println(jsonAfter.spaces2)
-      println("=====")
-      println("Diff:")
-      println(d)
-    }
-
-    d should be(Identical)
+    val diff = JsonDiff.diff(jsonBefore, jsonAfter, false)
+    diff should be(JsonPatch(Nil))
+    if (diff != JsonPatch(Nil)) println(diff)
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")
 
 resolvers += "twitter-repo" at "https://maven.twttr.com"
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.6.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.18.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.7")


### PR DESCRIPTION
Bumping the scrooge version is safe.
libthrift must not go beyond 0.9.1.
Circe 0.8.
Also switched from cornichon to diffson for json diffs in tests.