### PR TITLE
Revert cross paths change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ val mavenSettings = Seq(
 
 val commonSettings = Seq(
   scalaVersion := "2.12.3",
-  crossPaths := false,
+  crossScalaVersions := Seq("2.11.8", scalaVersion.value),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   organization := "com.gu",
   licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
@@ -103,8 +103,6 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
   .dependsOn(models)
   .settings(commonSettings)
   .settings(
-    crossPaths := true,
-    crossScalaVersions := Seq("2.11.8", scalaVersion.value),
     description := "Generated classes of the Scala models for the Guardian's Content API",
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
     scalacOptions ++= Seq("-deprecation", "-unchecked"),

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "11.26-SNAPSHOT"
+version in ThisBuild := "11.26"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "11.26"
+version in ThisBuild := "11.27-SNAPSHOT"


### PR DESCRIPTION
An earlier change enabled cross publishing (2.11 and 2.12). This had the unwanted side-effect of adding the scala version to the end of the name for *all* projects published by this library:
- `content-api-models-scala_2.12` - wanted
- `content-api-models-json_2.12` - not wanted
- `content-api-models_2.12` - not wanted

This other change that I reverted here attempted to fix this, but sbt doesn't allow you to only set `crossScalaVersions` for one project in a multi-project build. So the result was that only 2.12 was published.

We've decided to accept having scala versions after all projects, as we need cross publishing.