### PR TITLE
Bump to latest version of atom models to include new Timeline field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.50",
+      "com.gu" % "content-atom-model-thrift" % "2.4.51",
       "com.gu" % "content-entity-thrift" % "0.1.5",
       "com.gu" % "story-model-thrift" % "1.1"
     )


### PR DESCRIPTION
Changes in:
Porter https://github.com/guardian/content-api/pull/2021
Elasticsearch mapping https://github.com/guardian/content-api/pull/2020