### PR TITLE
Make time optional in CapiDateTime decoder

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -25,29 +25,29 @@ object CirceDecoders {
     }
   }
 
+  //We need this custom formatter because some fields in capi only have the date
+  val formatter = new DateTimeFormatterBuilder()
+    .parseCaseInsensitive()
+    .append(DateTimeFormatter.ISO_LOCAL_DATE)
+    .optionalStart
+    .appendLiteral('T')
+    .append(DateTimeFormatter.ISO_LOCAL_TIME)
+    .optionalStart
+    .appendOffsetId
+    .optionalEnd
+    .optionalEnd
+    .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+    .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+    .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+    .parseDefaulting(ChronoField.NANO_OF_SECOND, 0)
+    .parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
+    .toFormatter
+
   /**
     * A CapiDateTime is an object with 2 fields. We currently need to support decoding from
     * a string or an object.
     */
   implicit val dateTimeDecoder: Decoder[CapiDateTime] = new Decoder[CapiDateTime] {
-    //We need this custom formatter because some fields in capi only have the date
-    private val formatter = new DateTimeFormatterBuilder()
-      .parseCaseInsensitive()
-      .append(DateTimeFormatter.ISO_LOCAL_DATE)
-      .optionalStart
-      .appendLiteral('T')
-      .append(DateTimeFormatter.ISO_LOCAL_TIME)
-      .optionalStart
-      .appendOffsetId
-      .optionalEnd
-      .optionalEnd
-      .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-      .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
-      .parseDefaulting(ChronoField.NANO_OF_SECOND, 0)
-      .parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
-      .toFormatter
-
     final def apply(c: HCursor): Decoder.Result[CapiDateTime] = {
       val maybeResult = c.value.asObject.map { obj =>
         val map = obj.toMap

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -8,7 +8,9 @@ import cats.syntax.either._
 import com.gu.contententity.thrift.Entity
 import com.gu.story.model.v1.Story
 import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
+import java.time.chrono.IsoChronology
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, ResolverStyle}
+import java.time.temporal.ChronoField
 
 object CirceDecoders {
 
@@ -28,6 +30,22 @@ object CirceDecoders {
     * a string or an object.
     */
   implicit val dateTimeDecoder: Decoder[CapiDateTime] = new Decoder[CapiDateTime] {
+    //We need this custom formatter because some fields in capi only have the date
+    private val formatter = new DateTimeFormatterBuilder()
+      .parseCaseInsensitive()
+      .append(DateTimeFormatter.ISO_LOCAL_DATE)
+      .optionalStart
+      .appendLiteral('T')
+      .append(DateTimeFormatter.ISO_LOCAL_TIME)
+      .appendOffsetId
+      .optionalEnd
+      .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+      .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+      .parseDefaulting(ChronoField.NANO_OF_SECOND, 0)
+      .parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
+      .toFormatter
+
     final def apply(c: HCursor): Decoder.Result[CapiDateTime] = {
       val maybeResult = c.value.asObject.map { obj =>
         val map = obj.toMap
@@ -42,7 +60,7 @@ object CirceDecoders {
 
       } orElse {
         c.value.asString.map { dateTimeString =>
-          val dateTime: OffsetDateTime = OffsetDateTime.parse(dateTimeString)
+          val dateTime = OffsetDateTime.parse(dateTimeString, formatter)
           Either.right(CapiDateTime.apply(dateTime.toInstant.toEpochMilli(), DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dateTime)))
         }
       }

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -37,7 +37,9 @@ object CirceDecoders {
       .optionalStart
       .appendLiteral('T')
       .append(DateTimeFormatter.ISO_LOCAL_TIME)
+      .optionalStart
       .appendOffsetId
+      .optionalEnd
       .optionalEnd
       .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
       .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)

--- a/json/src/test/scala/com/gu/contentapi/json/CirceRoundTripSpec.scala
+++ b/json/src/test/scala/com/gu/contentapi/json/CirceRoundTripSpec.scala
@@ -2,7 +2,7 @@ package com.gu.contentapi.json
 
 import com.gu.contentapi.client.model.v1._
 import com.gu.contentapi.json.utils.JsonHelpers._
-import io.circe.{Decoder, Encoder, Json}
+import io.circe._
 import io.circe.syntax._
 import io.circe.parser._
 import io.circe.optics.JsonPath._
@@ -93,6 +93,12 @@ class CirceRoundTripSpec extends FlatSpec with Matchers {
       jsonAfter should be(Some(Json.fromString("2016-05-04T12:34:56+01:00")))
     }
   }
+
+    it should "parse date with no time" in {
+      val jsonBefore = Json.fromString("2016-05-04")
+      val capiDateTime = jsonBefore.as[CapiDateTime].toOption
+      capiDateTime should be(Some(CapiDateTime(1462320000000L, "2016-05-04T00:00:00Z")))
+    }
 
   it should "round-trip an ItemResponse with a quiz atom" in {
     checkRoundTrip[ItemResponse]("item-content-with-atom-quiz.json")

--- a/json/src/test/scala/com/gu/contentapi/json/CirceRoundTripSpec.scala
+++ b/json/src/test/scala/com/gu/contentapi/json/CirceRoundTripSpec.scala
@@ -94,11 +94,17 @@ class CirceRoundTripSpec extends FlatSpec with Matchers {
     }
   }
 
-    it should "parse date with no time" in {
-      val jsonBefore = Json.fromString("2016-05-04")
-      val capiDateTime = jsonBefore.as[CapiDateTime].toOption
-      capiDateTime should be(Some(CapiDateTime(1462320000000L, "2016-05-04T00:00:00Z")))
-    }
+  it should "parse date with no time" in {
+    val jsonBefore = Json.fromString("2016-05-04")
+    val capiDateTime = jsonBefore.as[CapiDateTime].toOption
+    capiDateTime should be(Some(CapiDateTime(1462320000000L, "2016-05-04T00:00:00Z")))
+  }
+
+  it should "parse date with no zone" in {
+    val jsonBefore = Json.fromString("2015-10-22T17:02:41")
+    val capiDateTime = jsonBefore.as[CapiDateTime].toOption
+    capiDateTime should be(Some(CapiDateTime(1445533361000L, "2015-10-22T17:02:41Z")))
+  }
 
   it should "round-trip an ItemResponse with a quiz atom" in {
     checkRoundTrip[ItemResponse]("item-content-with-atom-quiz.json")


### PR DESCRIPTION
The recent move from joda to java time breaks the decoding of elasticsearch json in Concierge.
This is because some of these fields have only a date, and the joda time parser was less strict.

I've tested locally with concierge.

@annebyrne this was blocking your concierge version bump :(