### PR TITLE
Include podcast level info about types - serial or episodic

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1099,6 +1099,8 @@ struct Podcast {
     6: optional string image
 
     7: optional list<PodcastCategory> categories
+
+    8: optional string podcastType
 }
 
 struct Tag {


### PR DESCRIPTION
In the iOS 11 update, we can now include podcast level information about the `type` of the podcast, whether they are serial or episodic. This will impact how episodes of podcast are shown to the user.