### PR TITLE
Add pillar fields to Content

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -109,6 +109,7 @@ object CirceDecoders {
   implicit val atomDataDecoder = Decoder[AtomData]
   implicit val atomDecoder = Decoder[Atom]
   implicit val atomsDecoder = Decoder[Atoms]
+  implicit val pillarDecoder = Decoder[Pillar]
   implicit val contentDecoder = Decoder[Content]
   implicit val mostViewedVideoDecoder = Decoder[MostViewedVideo]
   implicit val pathAndStoryQuestionsAtomIdDecoder = Decoder[PathAndStoryQuestionsAtomId]
@@ -131,6 +132,7 @@ object CirceDecoders {
   implicit val ophanStoryQuestionsResponseDecoder = Decoder[OphanStoryQuestionsResponse]
   implicit val storyDecoder = Decoder[Story]
   implicit val storiesResponseDecoder = Decoder[StoriesResponse]
+  implicit val pillarsResponseDecoder = Decoder[PillarsResponse]
 
   // These two need to be written manually. I think the `Map[K, V]` type having 2 type params causes implicit divergence,
   // although shapeless's Lazy is supposed to work around that.

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -63,6 +63,7 @@ object CirceEncoders {
   implicit val atomDataEncoder = Encoder[AtomData]
   implicit val atomEncoder = Encoder[Atom]
   implicit val atomsEncoder = Encoder[Atoms]
+  implicit val pillarEncoder = Encoder[Pillar]
   implicit val contentEncoder = Encoder[Content]
   implicit val mostViewedVideoEncoder = Encoder[MostViewedVideo]
   implicit val pathAndStoryQuestionsAtomIdEncoder = Encoder[PathAndStoryQuestionsAtomId]
@@ -82,6 +83,7 @@ object CirceEncoders {
   implicit val ophanStoryQuestionsResponseEncoder = Encoder[OphanStoryQuestionsResponse]
   implicit val storyEncoder = Encoder[Story]
   implicit val storiesResponseEncoder = Encoder[StoriesResponse]
+  implicit val pillarsResponseEncoder = Encoder[PillarsResponse]
 
   def genDateTimeEncoder: Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>
     val dateTime: OffsetDateTime = OffsetDateTime.parse(capiDateTime.iso8601)

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1608,6 +1608,13 @@ struct MostViewedVideo {
     2: required i32 count
 }
 
+struct Pillar {
+    1: required string id
+
+    2: required string name
+
+    3: required list<string> sectionIds
+}
 
 /* These are Responses structures shared with the Content API */
 
@@ -1881,3 +1888,12 @@ struct StoriesResponse {
 
     3: required list<story_model.Story> results
 }
+
+struct PillarsResponse {
+    1: required string status
+
+    2: required i32 total
+
+    3: required list<Pillar> results
+}
+

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1532,6 +1532,10 @@ struct Content {
      * Indicates whether the content is hosted content i.e content we have been paid to put on the Guardian.
      */
     23: required bool isHosted = false
+
+    24: optional string pillarId
+
+    25: optional string pillarName
 }
 
 struct NetworkFront {


### PR DESCRIPTION
In addition to `sectionId`/`sectionName`, capi will now also return the pillar details.
Concierge will determine the pillar from the content's `sectionId`.