### PR TITLE
Bump version to include new Snippet Timeline date formats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.53",
+      "com.gu" % "content-atom-model-thrift" % "2.4.54",
       "com.gu" % "content-entity-thrift" % "0.1.5",
       "com.gu" % "story-model-thrift" % "1.1"
     )


### PR DESCRIPTION
Associated relevant PRs for change that have been merged:

- [x] content-atom
- [ ]  content-api/elasticsearch
- [ ]  atom-workshop
- [ ]  content-api/porter
- [ ]  content-api-scala-client
- [ ]  frontend