### PR TITLE
Increment version of content-atom-models 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val models = Project(id = "content-api-models", base = file("models"))
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     libraryDependencies ++= Seq(
       "com.gu" % "story-packages-model-thrift" % "1.0.3",
-      "com.gu" % "content-atom-model-thrift" % "2.4.60",
+      "com.gu" % "content-atom-model-thrift" % "2.4.61",
       "com.gu" % "content-entity-thrift" % "0.1.5",
       "com.gu" % "story-model-thrift" % "1.1"
     )


### PR DESCRIPTION
Added new properties to content atom models, so bumping the version here to pull in the latest 

[Trello Ticket](https://trello.com/c/GexFvYIf/240-add-new-fields-for-atom-images-adding-fields-for-atom-images-copyright-source-photographer-suppliersreference-so-rcs-can-better)

