### PR TITLE
Upgrade to Cats 1.0 - by upgrading relevant libraries that use it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: scala
 scala:
-  - 2.11.11
-  - 2.12.3
+  - 2.11.12
+  - 2.12.4
 jdk:
   - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -45,14 +45,15 @@ val mavenSettings = Seq(
 )
 
 val commonSettings = Seq(
-  scalaVersion := "2.12.3",
-  crossScalaVersions := Seq("2.11.8", scalaVersion.value),
+  scalaVersion := "2.12.4",
+  crossScalaVersions := Seq("2.11.12", scalaVersion.value),
+  scalacOptions += "-Ypartial-unification", // Cats requires this: https://github.com/typelevel/cats/pull/1946/files
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   organization := "com.gu",
   licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 ) ++ mavenSettings
 
-val circeVersion = "0.8.0"
+val circeVersion = "0.9.0"
 
 /**
   * Root project
@@ -139,12 +140,12 @@ lazy val json = Project(id = "content-api-models-json", base = file("json"))
   .settings(
     description := "Json parser for the Guardian's Content API models",
     libraryDependencies ++= Seq(
-      "com.gu" %% "fezziwig" % "0.6",
+      "com.gu" %% "fezziwig" % "0.8",
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-optics" % circeVersion,
-      "org.gnieh" %% "diffson-circe" % "2.2.2" % "test",
+      "org.gnieh" %% "diffson-circe" % "2.2.5" % "test",
       "org.scalatest" %% "scalatest" % "3.0.1" % "test",
       "com.google.guava" % "guava" % "19.0" % "test"
     ),


### PR DESCRIPTION
In Ophan we use both the Content API client and [`play-googleauth`](https://github.com/guardian/play-googleauth).

`play-googleauth` was recently updated to use Cats 1.0.1 with https://github.com/guardian/play-googleauth/pull/49, and we have our own PR sitting on top of this (https://github.com/guardian/play-googleauth/pull/52) that we want to start using - but first we need the Content API client to also be updated to Cats 1.0, along with Circe etc, otherwise we get all kinds of _runtime_ errors, some of the associated with the Circe version, eg:

```
java.lang.NoSuchMethodError: io.circe.Decoder$.decodeCanBuildFrom(Lio/circe/Decoder;Lscala/collection/generic/CanBuildFrom;)Lio/circe/Decoder;
at com.gu.contentapi.json.CirceDecoders$.<init>(CirceDecoders.scala:82)
at com.gu.contentapi.json.CirceDecoders$.<clinit>(CirceDecoders.scala)
at ophan.PersistentContentTest$$anonfun$4.apply(PersistentContentTest.scala:389)
```
