### PR TITLE
Upgrade lib thrift and scrooge-core version to same as ophan-event-model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,8 +121,8 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
       (scroogeUnpackDeps in Compile).value.flatMap { dir => (dir ** "*.thrift").get }
     },
     libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.9.1",
-      "com.twitter" %% "scrooge-core" % "4.18.0"
+      "org.apache.thrift" % "libthrift" % "0.9.3",
+      "com.twitter" %% "scrooge-core" % "4.20.0"
     ),
 
     /**


### PR DESCRIPTION
Reduce number of binary incompatibility warnings in other projects