### PR TITLE
Add new showAffiliateLinks field

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1070,6 +1070,8 @@ struct ContentFields {
     48: optional bool shouldHideReaderRevenue
 
     49: optional i32 internalCommissionedWordcount
+
+    50: optional bool showAffiliateLinks
 }
 
 struct Reference {


### PR DESCRIPTION
This field will be set in composer, and used by frontend to determine whether affiliate links are displayed within an article.

Background: We're going to start automatically adding affiliate links to content in certain sections (e.g. lifeandstyle). They come from a service called skimlinks. Sometimes we'll need to manually turn them off for sensitive content, or force them to be on for content not in one of the whitelisted sections.