### PR TITLE
Add lastModified to RemovedContentResponse

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -116,6 +116,7 @@ object CirceDecoders {
   implicit val networkFrontDecoder = Decoder[NetworkFront]
   implicit val packageArticleDecoder = Decoder[PackageArticle]
   implicit val packageDecoder = Decoder[Package]
+  implicit val removedContentDecoder = Decoder[RemovedContent]
   implicit val itemResponseDecoder = Decoder[ItemResponse]
   implicit val searchResponseDecoder = Decoder[SearchResponse]
   implicit val editionsResponseDecoder = Decoder[EditionsResponse]

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -68,6 +68,7 @@ object CirceEncoders {
   implicit val mostViewedVideoEncoder = Encoder[MostViewedVideo]
   implicit val pathAndStoryQuestionsAtomIdEncoder = Encoder[PathAndStoryQuestionsAtomId]
   implicit val packageEncoder = Encoder[Package]
+  implicit val removedContentEncoder = Encoder[RemovedContent]
   implicit val itemResponseEncoder = Encoder[ItemResponse]
   implicit val searchResponseEncoder = Encoder[SearchResponse]
   implicit val editionsResponseEncoder = Encoder[EditionsResponse]

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1629,6 +1629,12 @@ struct Pillar {
     3: required list<string> sectionIds
 }
 
+struct RemovedContent {
+    1: required string id
+
+    2: required CapiDateTime lastModified
+}
+
 /* These are Responses structures shared with the Content API */
 
 struct SearchResponse {
@@ -1828,6 +1834,8 @@ struct RemovedContentResponse {
     8: required string orderBy
 
     9: required list<string> results
+
+    10: optional list<RemovedContent> resultsWithLastModified
 }
 
 struct ErrorResponse {


### PR DESCRIPTION
Needed by crier for [new design](https://github.com/guardian/crier/pull/79).
For backwards-compatibility, this must be a new field.
It can be optionally returned by capi if clients request it