### PR TITLE
Add support for fractional part in timestamps

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -33,6 +33,9 @@ object CirceDecoders {
     .appendLiteral('T')
     .append(DateTimeFormatter.ISO_LOCAL_TIME)
     .optionalStart
+    .appendFraction(ChronoField.NANO_OF_SECOND, 3, 3, false)
+    .optionalEnd
+    .optionalStart
     .appendOffsetId
     .optionalEnd
     .optionalEnd

--- a/json/src/test/resources/templates/item-content.json
+++ b/json/src/test/resources/templates/item-content.json
@@ -450,6 +450,9 @@
                 "syndicatable": true,
                 "subscriptionDatabases": true,
                 "developerCommunity": true
+            },
+            "debug": {
+                "lastSeenByPorterAt": "2013-01-16T10:14:31.634Z"        
             }
         }
     }


### PR DESCRIPTION
Following the update of Porter, we now serialise timestamps with milliseconds precision when available for the `lastSeenByPorterAt` field. Sadly this requires a custom `Debug` encoder.