### PR TITLE
Tag Podcast change: Add google podcasts url

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1107,6 +1107,8 @@ struct Podcast {
     7: optional list<PodcastCategory> categories
 
     8: optional string podcastType
+
+    9: optional string googlePodcastsUrl
 }
 
 struct Tag {


### PR DESCRIPTION
We want Podcast series to have a `googlePodcastsUrl` link as well as an iTunes one (named `subscriptionUrl`.

Related: 

https://github.com/guardian/content-api/pull/2171

https://github.com/guardian/content-api/pull/2170