### PR TITLE
Model non-web content

### DIFF
--- a/models/src/main/thrift/content/CapiDateTime.thrift
+++ b/models/src/main/thrift/content/CapiDateTime.thrift
@@ -1,0 +1,18 @@
+namespace scala com.gu.contentapi.client.model.v1
+
+struct CapiDateTime {
+
+    /*
+     * Date times are represented as i64 - epoch millis
+     */
+    1: required i64 dateTime
+
+    /*
+     * Also represent as a string (yyyy-MM-dd`T`HH:mm:ss.SSSZZ) in order to preserve timezone info.
+     *
+     * Note: this field makes the i64 representation redundant.
+     */
+    2: required string iso8601
+
+}
+

--- a/models/src/main/thrift/content/Platform.thrift
+++ b/models/src/main/thrift/content/Platform.thrift
@@ -15,15 +15,15 @@ struct WebPlatform {
 
   1: required string title
 
-  2: required CapiDateTime publicationDate
+  2: required CapiDateTime.CapiDateTime publicationDate
 }
 
 struct PrintPlatform {
   0: required i32 pageNumber
     
-  1: required CapiDateTime editionDate
+  1: required CapiDateTime.CapiDateTime editionDate
 }
 
 struct EditionPlatform {
-  0: required CapiDateTime editionDate
+  0: required CapiDateTime.CapiDateTime editionDate
 }

--- a/models/src/main/thrift/content/Platform.thrift
+++ b/models/src/main/thrift/content/Platform.thrift
@@ -1,6 +1,7 @@
 namespace scala com.gu.contentapi.client.model.v1
 
 include "CapiDateTime.thrift"
+include "Tag.thrift"
 
 enum Platform {
   WEB = 0
@@ -33,13 +34,13 @@ struct PrintFields {
   // cheat for now and re-use the existing tags
 
   // This should be the publication tag
-  1: required Tag publication
+  1: required Tag.Tag publication
 
   // This should be the book tag
-  2: required Tag book
+  2: required Tag.Tag book
 
   // This should be the book section tag
-  3: required Tag bookSection
+  3: required Tag.Tag bookSection
 
   // The page number this article was found on
   // Interestingly this might be multiple numbers for a spread and might change

--- a/models/src/main/thrift/content/Platform.thrift
+++ b/models/src/main/thrift/content/Platform.thrift
@@ -1,0 +1,29 @@
+namespace scala com.gu.contentapi.client.model.v1
+
+include "CapiDateTime.thrift"
+
+struct Platforms {
+  0: optional WebPlatform web;
+
+  1: optional PrintPlatform print;
+
+  2: optional EditionPlatform edition;
+}
+
+struct WebPlatform {
+  0: required string url
+
+  1: required string title
+
+  2: required CapiDateTime publicationDate
+}
+
+struct PrintPlatform {
+  0: required i32 pageNumber
+    
+  1: required CapiDateTime editionDate
+}
+
+struct EditionPlatform {
+  0: required CapiDateTime editionDate
+}

--- a/models/src/main/thrift/content/Podcast.thrift
+++ b/models/src/main/thrift/content/Podcast.thrift
@@ -1,0 +1,32 @@
+namespace scala com.gu.contentapi.client.model.v1
+
+
+struct PodcastCategory {
+
+    1: required string main
+
+    2: optional string sub
+}
+
+struct Podcast {
+
+    1: required string linkUrl
+
+    2: required string copyright
+
+    3: required string author
+
+    4: optional string subscriptionUrl
+
+    5: required bool explicit
+
+    6: optional string image
+
+    7: optional list<PodcastCategory> categories
+
+    8: optional string podcastType
+
+    9: optional string googlePodcastsUrl
+
+    10: optional string spotifyUrl
+}

--- a/models/src/main/thrift/content/Reference.thrift
+++ b/models/src/main/thrift/content/Reference.thrift
@@ -1,0 +1,9 @@
+namespace scala com.gu.contentapi.client.model.v1
+
+struct Reference {
+
+    1: required string id
+
+    2: required string type
+}
+

--- a/models/src/main/thrift/content/Sponsorship.thrift
+++ b/models/src/main/thrift/content/Sponsorship.thrift
@@ -1,0 +1,49 @@
+namespace scala com.gu.contentapi.client.model.v1
+
+include "CapiDateTime.thrift"
+
+enum SponsorshipType {
+    SPONSORED = 0,
+    FOUNDATION = 1,
+    PAID_CONTENT = 2
+}
+
+struct SponsorshipTargeting {
+    1: optional CapiDateTime.CapiDateTime publishedSince
+
+    2: optional list<string> validEditions
+}
+
+struct SponsorshipLogoDimensions {
+
+    1: required i32 width
+
+    2: required i32 height
+
+}
+
+struct Sponsorship {
+
+    1: required SponsorshipType sponsorshipType
+
+    2: required string sponsorName
+
+    3: required string sponsorLogo
+
+    4: required string sponsorLink
+
+    5: optional SponsorshipTargeting targeting
+
+    6: optional string aboutLink
+
+    7: optional SponsorshipLogoDimensions sponsorLogoDimensions
+
+    8: optional string highContrastSponsorLogo
+
+    9: optional SponsorshipLogoDimensions highContrastSponsorLogoDimensions
+
+    10: optional CapiDateTime.CapiDateTime validFrom
+
+    11: optional CapiDateTime.CapiDateTime validTo
+
+}

--- a/models/src/main/thrift/content/Tag.thrift
+++ b/models/src/main/thrift/content/Tag.thrift
@@ -1,0 +1,168 @@
+namespace scala com.gu.contentapi.client.model.v1
+
+include "Podcast.thrift"
+include "Reference.thrift"
+include "Sponsorship.thrift"
+
+enum TagType {
+
+    CONTRIBUTOR = 0,
+
+    KEYWORD = 1,
+
+    SERIES = 2,
+
+    NEWSPAPER_BOOK_SECTION = 3,
+
+    NEWSPAPER_BOOK = 4,
+
+    BLOG = 5,
+
+    TONE = 6,
+
+    TYPE = 7,
+
+    PUBLICATION = 8,
+
+    TRACKING = 9,
+
+    PAID_CONTENT = 10,
+
+    CAMPAIGN = 11
+
+}
+
+struct Tag {
+
+    /*
+     * The id of this tag: this should always be the path
+     * to the tag page on www.theguardian.com
+     */
+    1: required string id
+
+    /*
+     * The type of this tag
+     */
+    2: required TagType type
+
+    /*
+     * Section is usually provided: some tags (notably contributor tags)
+     * does not belong to any section so this will be None
+     */
+    3: optional string sectionId
+
+    /*
+     * The display name of the section.  Will be None if sectionId is None.
+     */
+    4: optional string sectionName
+
+    /*
+     * Short description of this tag.
+     */
+    5: required string webTitle
+
+    /*
+     * Full url on which tag page can be found on www.theguardian.com
+     */
+    6: required string webUrl
+
+    /*
+     * Full url on which full information about this tag can be found on
+     * the content api.
+     *
+     * For tags, this allows access to the editorsPicks for the tag,
+     * and automatically shows the most recent content for the tag.
+     */
+    7: required string apiUrl
+
+    /*
+     * List of references associated with the tag. References are
+     * strings that identify things beyond the content api. A good example
+     * is an isbn number, which associates the tag with a book.
+     *
+     * Use showReferences passing in the the type of reference you want to
+     * see or 'all' to see all references.
+     */
+    8: required list<Reference.Reference> references
+
+    /**
+     * A tag *may* have a description field.
+     *
+     * Contributor tags never have a description field. They may
+     * instead have a 'bio' field.
+     */
+    9: optional string description
+
+    /**
+     * If this tag is a contributor then we *may* have a small bio
+     * for the contributor.
+     *
+     * This field is optional in all cases, even contributors are not
+     * guaranteed to have one.
+     */
+    10: optional string bio
+
+    /*
+     * If this tag is a contributor then we *may* have a small byline
+     * picturefor the contributor.
+     *
+     * This field is optional in all cases, even contributors are not
+     * guaranteed to have one.
+     */
+    11: optional string bylineImageUrl
+
+    /**
+     * If this tag is a contributor then we *may* have a large byline
+     * picture for the contributor.
+     */
+    12: optional string bylineLargeImageUrl
+
+    /*
+     * If this tag is a series it could be a podcast.
+     */
+    13: optional Podcast.Podcast podcast
+
+    /*
+     * If the tag is a contributor it may have a first name, a last name, email address and a twitter handle.
+     */
+    14: optional string firstName
+
+    15: optional string lastName
+
+    16: optional string emailAddress
+
+    17: optional string twitterHandle
+
+    /**
+    * A list of all the active sponsorships running against this tag
+    */
+    18: optional list<Sponsorship.Sponsorship> activeSponsorships
+
+    19: optional string paidContentType
+
+    20: optional string paidContentCampaignColour
+
+    21: optional string rcsId
+
+    22: optional string r2ContributorId
+
+    /*
+     * A set of schema.org types, e.g. "Person", "Place"
+     */
+    23: optional set<string> tagCategories
+
+    /*
+     * A set of Guardian Entity IDs associated with this Tag
+     */
+    24: optional set<string> entityIds
+
+    /**
+    * If the tag is a campaign, it should have a subtype eg callout
+    */
+    25: optional string campaignInformationType
+
+    /**
+    * The internal name of the tag
+    */
+    26: optional string internalName
+}

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -2,7 +2,7 @@ include "story_package_article.thrift"
 include "contentatom.thrift"
 include "entity.thrift"
 include "story_model.thrift"
-include "platform.thrift"
+include "Platform.thrift"
 include "CapiDateTime.thrift"
 
 namespace scala com.gu.contentapi.client.model.v1

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -320,7 +320,7 @@ struct AssetFields {
 
   54: optional string apiUrl
 
-  55: optional CapiDateTime dateCreated
+  55: optional CapiDateTime.CapiDateTime dateCreated
 
   56: optional string youtubeUrl
 
@@ -342,9 +342,9 @@ struct AssetFields {
 
   65: optional string price
 
-  66: optional CapiDateTime start
+  66: optional CapiDateTime.CapiDateTime start
 
-  67: optional CapiDateTime end
+  67: optional CapiDateTime.CapiDateTime end
 
   68: optional bool safeEmbedCode
 }
@@ -533,7 +533,7 @@ struct WitnessElementFields {
     16: optional string html
     17: optional string apiUrl
     18: optional string photographer
-    19: optional CapiDateTime dateCreated
+    19: optional CapiDateTime.CapiDateTime dateCreated
     20: optional string youtubeUrl
     21: optional string youtubeSource
     22: optional string youtubeTitle
@@ -545,7 +545,7 @@ struct WitnessElementFields {
 
 
 struct SponsorshipTargeting {
-    1: optional CapiDateTime publishedSince
+    1: optional CapiDateTime.CapiDateTime publishedSince
 
     2: optional list<string> validEditions
 }
@@ -578,9 +578,9 @@ struct Sponsorship {
 
     9: optional SponsorshipLogoDimensions highContrastSponsorLogoDimensions
 
-    10: optional CapiDateTime validFrom
+    10: optional CapiDateTime.CapiDateTime validFrom
 
-    11: optional CapiDateTime validTo
+    11: optional CapiDateTime.CapiDateTime validTo
 
 }
 
@@ -603,8 +603,8 @@ struct MembershipElementFields {
     7: optional string identifier
     8: optional string image
     9: optional string price
-    10: optional CapiDateTime start
-    11: optional CapiDateTime end
+    10: optional CapiDateTime.CapiDateTime start
+    11: optional CapiDateTime.CapiDateTime end
 }
 
 struct EmbedElementFields {
@@ -803,22 +803,22 @@ struct Block {
     /*
      * The first time this block was created.
      */
-    7: optional CapiDateTime createdDate
+    7: optional CapiDateTime.CapiDateTime createdDate
 
     /*
      * The first time this block was published.
      */
-    8: optional CapiDateTime firstPublishedDate
+    8: optional CapiDateTime.CapiDateTime firstPublishedDate
 
     /*
      * The last time this block was published.
      */
-    9: optional CapiDateTime publishedDate
+    9: optional CapiDateTime.CapiDateTime publishedDate
 
     /*
      * The last time this block was modified.
      */
-    10: optional CapiDateTime lastModifiedDate
+    10: optional CapiDateTime.CapiDateTime lastModifiedDate
 
     /*
      * People who contributed to this block.
@@ -921,7 +921,7 @@ struct Crossword {
 
     3: required i32 number
 
-    4: required CapiDateTime date
+    4: required CapiDateTime.CapiDateTime date
 
     5: required CrosswordDimensions dimensions
 
@@ -941,7 +941,7 @@ struct Crossword {
 
     13: optional string annotatedSolution
 
-    14: optional CapiDateTime dateSolutionAvailable
+    14: optional CapiDateTime.CapiDateTime dateSolutionAvailable
 
 }
 
@@ -982,15 +982,15 @@ struct ContentFields {
 
     11: optional i32 wordcount
 
-    12: optional CapiDateTime commentCloseDate
+    12: optional CapiDateTime.CapiDateTime commentCloseDate
 
     13: optional bool commentable
 
-    14: optional CapiDateTime creationDate
+    14: optional CapiDateTime.CapiDateTime creationDate
 
     15: optional string displayHint
 
-    16: optional CapiDateTime firstPublicationDate
+    16: optional CapiDateTime.CapiDateTime firstPublicationDate
 
     17: optional bool hasStoryPackage
 
@@ -1006,17 +1006,17 @@ struct ContentFields {
 
     23: optional bool isPremoderated
 
-    24: optional CapiDateTime lastModified
+    24: optional CapiDateTime.CapiDateTime lastModified
 
     25: optional bool liveBloggingNow
 
-    26: optional CapiDateTime newspaperEditionDate
+    26: optional CapiDateTime.CapiDateTime newspaperEditionDate
 
     27: optional Office productionOffice
 
     28: optional string publication
 
-    29: optional CapiDateTime scheduledPublicationDate
+    29: optional CapiDateTime.CapiDateTime scheduledPublicationDate
 
     30: optional string secureThumbnail
 
@@ -1416,7 +1416,7 @@ struct ContentStats {
 
 struct Debug {
 
-    1: optional CapiDateTime lastSeenByPorterAt
+    1: optional CapiDateTime.CapiDateTime lastSeenByPorterAt
 
     2: optional i64 revisionSeenByPorter
 
@@ -1455,7 +1455,7 @@ struct Content {
      * "significant updates" are made to a story the web publication date is
      * updated.
      */
-    5: optional CapiDateTime webPublicationDate
+    5: optional CapiDateTime.CapiDateTime webPublicationDate
 
     /*
      * Short description of this item of content.
@@ -1553,7 +1553,7 @@ struct Content {
 
     25: optional string pillarName
 
-    26: optional Platforms platforms
+    26: optional Platform.Platforms platforms
 }
 
 struct NetworkFront {
@@ -1614,7 +1614,7 @@ struct Package {
     /* The package name */
     3: required string packageName
 
-    4: required CapiDateTime lastModified
+    4: required CapiDateTime.CapiDateTime lastModified
 }
 
 struct MostViewedVideo {
@@ -1637,7 +1637,7 @@ struct Pillar {
 struct RemovedContent {
     1: required string id
 
-    2: required CapiDateTime lastModified
+    2: required CapiDateTime.CapiDateTime lastModified
 }
 
 /* These are Responses structures shared with the Content API */

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -2,26 +2,12 @@ include "story_package_article.thrift"
 include "contentatom.thrift"
 include "entity.thrift"
 include "story_model.thrift"
+include "platform.thrift"
+include "CapiDateTime.thrift"
 
 namespace scala com.gu.contentapi.client.model.v1
 
 //include "atoms/quiz.thrift"
-
-struct CapiDateTime {
-
-    /*
-     * Date times are represented as i64 - epoch millis
-     */
-    1: required i64 dateTime
-
-    /*
-     * Also represent as a string (yyyy-MM-dd`T`HH:mm:ss.SSSZZ) in order to preserve timezone info.
-     *
-     * Note: this field makes the i64 representation redundant.
-     */
-    2: required string iso8601
-
-}
 
 enum ContentType {
     ARTICLE = 0,
@@ -1566,6 +1552,8 @@ struct Content {
     24: optional string pillarId
 
     25: optional string pillarName
+
+    26: optional Platforms platforms
 }
 
 struct NetworkFront {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -2,8 +2,11 @@ include "story_package_article.thrift"
 include "contentatom.thrift"
 include "entity.thrift"
 include "story_model.thrift"
-include "Platform.thrift"
 include "CapiDateTime.thrift"
+include "Platform.thrift"
+include "Reference.thrift"
+include "Sponsorship.thrift"
+include "Tag.thrift"
 
 namespace scala com.gu.contentapi.client.model.v1
 
@@ -129,34 +132,6 @@ enum ElementType {
 
 }
 
-enum TagType {
-
-    CONTRIBUTOR = 0,
-
-    KEYWORD = 1,
-
-    SERIES = 2,
-
-    NEWSPAPER_BOOK_SECTION = 3,
-
-    NEWSPAPER_BOOK = 4,
-
-    BLOG = 5,
-
-    TONE = 6,
-
-    TYPE = 7,
-
-    PUBLICATION = 8,
-
-    TRACKING = 9,
-
-    PAID_CONTENT = 10,
-
-    CAMPAIGN = 11
-
-}
-
 enum CrosswordType {
 
     QUICK = 0,
@@ -193,12 +168,6 @@ enum AssetType {
 enum MembershipTier {
     MEMBERS_ONLY = 0,
     PAID_MEMBERS_ONLY = 1
-}
-
-enum SponsorshipType {
-    SPONSORED = 0,
-    FOUNDATION = 1,
-    PAID_CONTENT = 2
 }
 
 struct Rights {
@@ -543,54 +512,13 @@ struct WitnessElementFields {
     26: optional string role
 }
 
-
-struct SponsorshipTargeting {
-    1: optional CapiDateTime.CapiDateTime publishedSince
-
-    2: optional list<string> validEditions
-}
-
-struct SponsorshipLogoDimensions {
-
-    1: required i32 width
-
-    2: required i32 height
-
-}
-
-struct Sponsorship {
-
-    1: required SponsorshipType sponsorshipType
-
-    2: required string sponsorName
-
-    3: required string sponsorLogo
-
-    4: required string sponsorLink
-
-    5: optional SponsorshipTargeting targeting
-
-    6: optional string aboutLink
-
-    7: optional SponsorshipLogoDimensions sponsorLogoDimensions
-
-    8: optional string highContrastSponsorLogo
-
-    9: optional SponsorshipLogoDimensions highContrastSponsorLogoDimensions
-
-    10: optional CapiDateTime.CapiDateTime validFrom
-
-    11: optional CapiDateTime.CapiDateTime validTo
-
-}
-
 struct RichLinkElementFields {
     1: optional string url
     2: optional string originalUrl
     3: optional string linkText
     4: optional string linkPrefix
     5: optional string role
-    6: optional Sponsorship sponsorship
+    6: optional Sponsorship.Sponsorship sponsorship
 }
 
 struct MembershipElementFields {
@@ -1066,178 +994,6 @@ struct ContentFields {
     51: optional string bylineHtml
 }
 
-struct Reference {
-
-    1: required string id
-
-    2: required string type
-}
-
-struct PodcastCategory {
-
-    1: required string main
-
-    2: optional string sub
-}
-
-struct Podcast {
-
-    1: required string linkUrl
-
-    2: required string copyright
-
-    3: required string author
-
-    4: optional string subscriptionUrl
-
-    5: required bool explicit
-
-    6: optional string image
-
-    7: optional list<PodcastCategory> categories
-
-    8: optional string podcastType
-
-    9: optional string googlePodcastsUrl
-
-    10: optional string spotifyUrl
-}
-
-struct Tag {
-
-    /*
-     * The id of this tag: this should always be the path
-     * to the tag page on www.theguardian.com
-     */
-    1: required string id
-
-    /*
-     * The type of this tag
-     */
-    2: required TagType type
-
-    /*
-     * Section is usually provided: some tags (notably contributor tags)
-     * does not belong to any section so this will be None
-     */
-    3: optional string sectionId
-
-    /*
-     * The display name of the section.  Will be None if sectionId is None.
-     */
-    4: optional string sectionName
-
-    /*
-     * Short description of this tag.
-     */
-    5: required string webTitle
-
-    /*
-     * Full url on which tag page can be found on www.theguardian.com
-     */
-    6: required string webUrl
-
-    /*
-     * Full url on which full information about this tag can be found on
-     * the content api.
-     *
-     * For tags, this allows access to the editorsPicks for the tag,
-     * and automatically shows the most recent content for the tag.
-     */
-    7: required string apiUrl
-
-    /*
-     * List of references associated with the tag. References are
-     * strings that identify things beyond the content api. A good example
-     * is an isbn number, which associates the tag with a book.
-     *
-     * Use showReferences passing in the the type of reference you want to
-     * see or 'all' to see all references.
-     */
-    8: required list<Reference> references
-
-    /**
-     * A tag *may* have a description field.
-     *
-     * Contributor tags never have a description field. They may
-     * instead have a 'bio' field.
-     */
-    9: optional string description
-
-    /**
-     * If this tag is a contributor then we *may* have a small bio
-     * for the contributor.
-     *
-     * This field is optional in all cases, even contributors are not
-     * guaranteed to have one.
-     */
-    10: optional string bio
-
-    /*
-     * If this tag is a contributor then we *may* have a small byline
-     * picturefor the contributor.
-     *
-     * This field is optional in all cases, even contributors are not
-     * guaranteed to have one.
-     */
-    11: optional string bylineImageUrl
-
-    /**
-     * If this tag is a contributor then we *may* have a large byline
-     * picture for the contributor.
-     */
-    12: optional string bylineLargeImageUrl
-
-    /*
-     * If this tag is a series it could be a podcast.
-     */
-    13: optional Podcast podcast
-
-    /*
-     * If the tag is a contributor it may have a first name, a last name, email address and a twitter handle.
-     */
-    14: optional string firstName
-
-    15: optional string lastName
-
-    16: optional string emailAddress
-
-    17: optional string twitterHandle
-
-    /**
-    * A list of all the active sponsorships running against this tag
-    */
-    18: optional list<Sponsorship> activeSponsorships
-
-    19: optional string paidContentType
-
-    20: optional string paidContentCampaignColour
-
-    21: optional string rcsId
-
-    22: optional string r2ContributorId
-
-    /*
-     * A set of schema.org types, e.g. "Person", "Place"
-     */
-    23: optional set<string> tagCategories
-
-    /*
-     * A set of Guardian Entity IDs associated with this Tag
-     */
-    24: optional set<string> entityIds
-
-    /**
-    * If the tag is a campaign, it should have a subtype eg callout
-    */
-    25: optional string campaignInformationType
-
-    /**
-    * The internal name of the tag
-    */
-    26: optional string internalName
-}
-
 struct Edition {
 
     /*
@@ -1301,7 +1057,7 @@ struct Section {
     /**
     * A list of all the active sponsorships running against this section
     */
-    6: optional list<Sponsorship> activeSponsorships
+    6: optional list<Sponsorship.Sponsorship> activeSponsorships
 }
 
 struct Atoms {
@@ -1494,7 +1250,7 @@ struct Content {
      * The order of tags is significant; tags towards the top of the list
      * are considered editorially more important than those towards the end.
      */
-    10: required list<Tag> tags = []
+    10: required list<Tag.Tag> tags = []
 
     /*
      * New representation to elements (assets lists) only returns if show-elements("all")
@@ -1510,7 +1266,7 @@ struct Content {
      * Use showReferences passing in the the type of reference you want to
      * see or 'all' to see all references.
      */
-    12: required list<Reference> references = []
+    12: required list<Reference.Reference> references = []
 
     /*
      * Set to true if the rights to this content have expired. Expired
@@ -1686,7 +1442,7 @@ struct ItemResponse {
 
     9: optional Content content
 
-    10: optional Tag tag
+    10: optional Tag.Tag tag
 
     11: optional Edition edition
 
@@ -1762,7 +1518,7 @@ struct TagsResponse {
 
     7: required i32 pages
 
-    8: required list<Tag> results
+    8: required list<Tag.Tag> results
 }
 
 struct SectionsResponse {


### PR DESCRIPTION
This is a strawman PR for thinking about non-web content in the concrete. As we discussed, the gist is that an article (`Content`) is augmented with some platform-specific context, that can be used as a filter in search queries (`?platform=web`) or as additional metadata (`?show-platforms=true`), assuming proper permissions from the consumer.

To that end, I add a `Platforms` data type that holds fields for each platform, where each is its own specific data type. There must be a least one non-empty value but thrift does not allow us to enforce that constraint. The advantage of that solution is that we keep everything in one place, unified under a single ID (the `path` of the article). However, that presumes the content and the metadata (related content, tags, story packages, etc.) will be the same across all platforms*. If we go down that path, we must make sure it is fine, otherwise we will have to add platform-specific fields to every data type inside articles, which is bad both for reasoning/writing correct code and performance.

\* this is not necessarily true for content if we can follow-up with platform-specific markup.

Alternatively, we discussed the idea of duplicating articles when content diverges, at the cost of changing the ID to `(path, platform)`. This introduces another set of tradeoffs. Notably that the content and metadata may be the same 99% of the time and that redundancy in CAPI is unnecessary, but also that it requires disambiguation logic at the boundaries of CAPI: Flexible will need to handle that redundancy, as well as Porter and Concierge. This isn't easy.

Did I summarise the design correctly?

On a side note, adding platform-specific fields opens up a can of worms, as articles in their current shape already contain some of them (`webTitle`, `newspaperEditionDate`) and it's interesting to think of how the data could be re-shaped in the future; meanwhile, a minimal amount of duplication seems harmless.