### PR TITLE
Unique publication instance

### DIFF
--- a/models/src/main/thrift/content/Platform.thrift
+++ b/models/src/main/thrift/content/Platform.thrift
@@ -3,22 +3,12 @@ namespace scala com.gu.contentapi.client.model.v1
 include "CapiDateTime.thrift"
 include "Tag.thrift"
 
-enum Platform {
-  WEB = 0
-  PRINT = 1
-  EDITION = 2
-}
+union PublicationInstance {
+  1: WebFields web
 
-struct PublicationInstance {
-  // let's have a platform enum to avoid ambiguity of this struct (only fields
-  // in the selected platform are relevant)
-  0: required Platform platform
+  2: PrintFields print
 
-  1: optional WebFields webFields
-
-  2: optional PrintFields printFields
-
-  3: optional EditionFields editionFields
+  3: EditionFields edition
 }
 
 struct WebFields {

--- a/models/src/main/thrift/content/Platform.thrift
+++ b/models/src/main/thrift/content/Platform.thrift
@@ -12,9 +12,11 @@ union PublicationInstance {
 }
 
 struct WebFields {
-  0: required string url // isn't this determined by the path???
+  0: required CapiDateTime.CapiDateTime publicationDate
 
-  1: required string title
+  1: required string url
+
+  2: required string title
 }
 
 struct PrintFields {
@@ -41,4 +43,7 @@ struct PrintFields {
 
 struct EditionFields {
   0: required CapiDateTime.CapiDateTime issueDate
+
+  // This should be the name of the app
+  1: required Tag.Tag publication
 }

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1312,7 +1312,7 @@ struct Content {
     /*
      * Where has this piece of content been published?
      */
-    26: optional list<Platform.PublicationInstance> publicationInstances
+    26: optional Platform.PublicationInstance publicationInstance
 }
 
 struct NetworkFront {


### PR DESCRIPTION
Just want to record the fruit of our session last week with @blishen @akash1810 @jonathonherbert  and @JustinPinner 

We adopt a "forking" model:

- a piece of content can only belong to one platform: this is because changes in the article made for that platform (which happens more often that not) cannot be reflected in the other instances. This is both true when a fork is for another platform or for the same platform as a reissue.

- in reflection, adding platform-specific annotations and content can quickly make the UI very complex and hard to understand and pushing that complexity "upwards" seems like a more realistic approach at the beginning: it is far easier to add a "fork/switch" UI.

- at the moment we don't track parent/child/sibling relationships in CAPI, but this can easily be added if necessary.