### PR TITLE
Add hook for emailsignup atoms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
       "org.apache.thrift" % "libthrift" % "0.12.0",
       "com.twitter" %% "scrooge-core" % "19.9.0",
       "com.gu" % "story-packages-model-thrift" % "2.0.2",
-      "com.gu" % "content-atom-model-thrift" % "3.1.2",
+      "com.gu" % "content-atom-model-thrift" % "3.2.0",
       "com.gu" % "content-entity-thrift" % "2.0.2"
     )
   )

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1354,6 +1354,8 @@ struct Atoms {
     15: optional list<contentatom.Atom> charts
 
     16: optional list<contentatom.Atom> audios
+
+    17: optional list<contentatom.Atom> emailsignups
 }
 
 struct ContentStats {


### PR DESCRIPTION
Now we have defined an emailsignup atom in https://github.com/guardian/content-atom/pull/133  and the latest version of [content-atom-model-thrift](https://search.maven.org/artifact/com.gu/content-atom-model-thrift) has been published, I'd like to use the latest version of content-atom-model-thrift