### PR TITLE
Remove stories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,8 +109,7 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
     scroogeThriftDependencies in Compile ++= Seq(
       "story-packages-model-thrift",
       "content-atom-model-thrift",
-      "content-entity-thrift",
-      "story-model-thrift"
+      "content-entity-thrift"
     ),
     // See: https://github.com/twitter/scrooge/issues/199
     scroogeThriftSources in Compile ++= {
@@ -122,8 +121,7 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
       "com.twitter" %% "scrooge-core" % "19.3.0",
       "com.gu" % "story-packages-model-thrift" % "2.0.1",
       "com.gu" % "content-atom-model-thrift" % "3.0.2",
-      "com.gu" % "content-entity-thrift" % "2.0.1",
-      "com.gu" % "story-model-thrift" % "2.0.1"
+      "com.gu" % "content-entity-thrift" % "2.0.1"
     )
   )
 

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -6,7 +6,6 @@ import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct,
 import com.gu.contentapi.client.model.v1._
 import cats.syntax.either._
 import com.gu.contententity.thrift.Entity
-import com.gu.story.model.v1.Story
 import java.time.OffsetDateTime
 import java.time.chrono.IsoChronology
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, ResolverStyle}
@@ -134,7 +133,6 @@ object CirceDecoders {
   implicit val entityDecoder = Decoder[Entity]
   implicit val entitiesResponseDecoder = Decoder[EntitiesResponse]
   implicit val ophanStoryQuestionsResponseDecoder = Decoder[OphanStoryQuestionsResponse]
-  implicit val storyDecoder = Decoder[Story]
   implicit val storiesResponseDecoder = Decoder[StoriesResponse]
   implicit val pillarsResponseDecoder = Decoder[PillarsResponse]
 

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -133,7 +133,6 @@ object CirceDecoders {
   implicit val entityDecoder = Decoder[Entity]
   implicit val entitiesResponseDecoder = Decoder[EntitiesResponse]
   implicit val ophanStoryQuestionsResponseDecoder = Decoder[OphanStoryQuestionsResponse]
-  implicit val storiesResponseDecoder = Decoder[StoriesResponse]
   implicit val pillarsResponseDecoder = Decoder[PillarsResponse]
 
   // These two need to be written manually. I think the `Map[K, V]` type having 2 type params causes implicit divergence,

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -93,7 +93,6 @@ object CirceEncoders {
   implicit val removedContentResponseEncoder = Encoder[RemovedContentResponse]
   implicit val entitiesResponseEncoder = Encoder[EntitiesResponse]
   implicit val ophanStoryQuestionsResponseEncoder = Encoder[OphanStoryQuestionsResponse]
-  implicit val storiesResponseEncoder = Encoder[StoriesResponse]
   implicit val pillarsResponseEncoder = Encoder[PillarsResponse]
 
   def genDateTimeEncoder(truncate: Boolean = true): Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -6,7 +6,6 @@ import io.circe._
 import io.circe.syntax._
 import com.gu.fezziwig.CirceScroogeMacros.{encodeThriftStruct, encodeThriftUnion}
 import com.gu.contentatom.thrift.{Atom, AtomData}
-import com.gu.story.model.v1.Story
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -94,7 +93,6 @@ object CirceEncoders {
   implicit val removedContentResponseEncoder = Encoder[RemovedContentResponse]
   implicit val entitiesResponseEncoder = Encoder[EntitiesResponse]
   implicit val ophanStoryQuestionsResponseEncoder = Encoder[OphanStoryQuestionsResponse]
-  implicit val storyEncoder = Encoder[Story]
   implicit val storiesResponseEncoder = Encoder[StoriesResponse]
   implicit val pillarsResponseEncoder = Encoder[PillarsResponse]
 

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1,7 +1,6 @@
 include "story_package_article.thrift"
 include "contentatom.thrift"
 include "entity.thrift"
-include "story_model.thrift"
 
 namespace scala com.gu.contentapi.client.model.v1
 
@@ -1738,8 +1737,6 @@ struct ItemResponse {
 
     28: optional contentatom.Atom storyquestions
 
-    29: optional story_model.Story story
-
     30: optional contentatom.Atom qanda
 
     31: optional contentatom.Atom guide
@@ -1922,15 +1919,6 @@ struct OphanStoryQuestionsResponse {
     1: required string status
 
     2: required list<PathAndStoryQuestionsAtomId> pathToAtomIds
-}
-
-struct StoriesResponse {
-
-    1: required string status
-
-    2: required i32 total
-
-    3: required list<story_model.Story> results
 }
 
 struct PillarsResponse {


### PR DESCRIPTION
Stories have been deleted from the scala client (see https://github.com/guardian/content-api-scala-client/pull/289) and CAPI (see https://github.com/guardian/content-api/pull/2304) so the models can also be cleaned out - when any clients have been updated.