### PR TITLE
Support typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,27 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models_2.12)
 [![Build Status](https://travis-ci.org/guardian/content-api-models.svg?branch=master)](https://travis-ci.org/guardian/content-api-models)
 
-To release:
+To release, in the SBT repl:
 
-```
-$ sbt 'release cross'
+```sbtshell
+release cross // will release the scala / thrift projects
+project typescript
+releaseNpm <version> // you have to specify the version again i.e releaseNpm 1.0.0
 ```
 
 will publish to [Maven Central](http://search.maven.org/) via Sonatype. You will need Sonatype credentials and a PGP key. It can take up to 2hrs to show up in search.
 
-## Information about built jars
+It will also release to NPM, ensure you have an NPM account, part of the [@guardian](https://www.npmjs.com/org/guardian) org with a [configured token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens)
 
-The content-api-models project builds the following jar files: 
+## Information about built bundles
 
-* content-api-models-scala - Scrooge generated class files based on the Thrift definitions of the content api models found in the `content-api-models` dependency. 
+The content-api-models project builds the following bundles: 
 
-* content-api-models-json - Json parsers and deserializers. Used internally by the content api and also by the `content-api-scala-client` to convert from Elasticsearch returned json to the Scrooge-generated Thrift classes. As a client you should never need to depend on this explicitly, although you may have a transitive dependency on it if using the `content-api-scala-client`.
+* content-api-models-scala - A jar containing Scrooge generated class files based on the Thrift definitions of the content api models found in the `content-api-models` dependency. 
 
-* content-api-models - Contains the Thrift definitions of the content api models only. As a client it is unlikely that you should ever need to depend on this but rather use the `content-api-models-scala` dependency instead.
+* content-api-models-json - A jar containing Json serializers and deserializers. Used internally by the content api and also by the `content-api-scala-client` to convert from Elasticsearch returned json to the Scrooge-generated Thrift classes. As a client you should never need to depend on this explicitly, although you may have a transitive dependency on it if using the `content-api-scala-client`.
+
+* content-api-models - A jar containing the Thrift definitions of the content api models only. As a client it is unlikely that you should ever need to depend on this but rather use the `content-api-models-scala` dependency instead.
+
+* [@guardian/content-api-models](https://www.npmjs.com/package/@guardian/content-api-models) - An npm package containing the generated models and their type definitions.
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models_2.12)
 [![Build Status](https://travis-ci.org/guardian/content-api-models.svg?branch=master)](https://travis-ci.org/guardian/content-api-models)
 
-To release, in the SBT repl:
+Ensure the version is composed of three parts (`1.2.3`) as NPM doesn't accept shorter versions such as `1.2`.
 
+The `release cross` command will publish to [Maven Central](http://search.maven.org/) via Sonatype. You will need Sonatype credentials and a PGP key. It can take up to 2hrs to show up in search.
+
+`release NPM` will release the typescript package to NPM. Ensure you have an NPM account, part of the [@guardian](https://www.npmjs.com/org/guardian) org with a [configured token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens)
+
+To release, in the SBT repl:
 ```sbtshell
 release cross // will release the scala / thrift projects
 project typescript
 releaseNpm <version> // you have to specify the version again i.e releaseNpm 1.0.0
 ```
-
-will publish to [Maven Central](http://search.maven.org/) via Sonatype. You will need Sonatype credentials and a PGP key. It can take up to 2hrs to show up in search.
-
-It will also release to NPM, ensure you have an NPM account, part of the [@guardian](https://www.npmjs.com/org/guardian) org with a [configured token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens)
 
 ## Information about built bundles
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,8 +45,8 @@ val mavenSettings = Seq(
 )
 
 val commonSettings = Seq(
-  scalaVersion := "2.13.1",
-  crossScalaVersions := Seq("2.11.12", "2.12.10", scalaVersion.value),
+  scalaVersion := "2.13.2",
+  crossScalaVersions := Seq("2.11.12", "2.12.11", scalaVersion.value),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   organization := "com.gu",
   licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -130,10 +130,10 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
     scroogePublishThrift in Compile := false,
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.12.0",
-      "com.twitter" %% "scrooge-core" % "19.9.0",
-      "com.gu" % "story-packages-model-thrift" % "2.0.2",
-      "com.gu" % "content-atom-model-thrift" % "3.2.0",
-      "com.gu" % "content-entity-thrift" % "2.0.2"
+      "com.twitter" %% "scrooge-core" % "20.4.1",
+      "com.gu" % "story-packages-model-thrift" % "2.0.3",
+      "com.gu" % "content-atom-model-thrift" % "3.2.1",
+      "com.gu" % "content-entity-thrift" % "2.0.5"
     )
   )
 
@@ -160,4 +160,33 @@ lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
     libraryDependencies += "com.google.guava" % "guava" % "19.0",
     javaOptions in Jmh ++= Seq("-server", "-Xms4G", "-Xmx4G", "-XX:+UseG1GC", "-XX:-UseBiasedLocking"),
     publishArtifact := false
+  )
+
+lazy val typescript = (project in file("ts"))
+  .enablePlugins(ScroogeTypescriptGen)
+  .settings(commonSettings)
+  .settings(
+    name := "content-api-models-typescript",
+    scroogeTypescriptNpmPackageName := "@guardian/content-api-models",
+    Compile / scroogeDefaultJavaNamespace := scroogeTypescriptNpmPackageName.value,
+    Test / scroogeDefaultJavaNamespace := scroogeTypescriptNpmPackageName.value,
+    description := "Typescript library built from the content api thrift definitions",
+
+    scroogeLanguages in Compile := Seq("typescript"),
+    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../models/src/main/thrift",
+
+    scroogeTypescriptPackageLicense := "Apache-2.0",
+    scroogeThriftDependencies in Compile ++= Seq("content-entity-thrift"),
+    scroogeTypescriptPackageMapping := Map(
+      "content-entity-thrift" -> "@guardian/content-entity-model",
+      "content-atom-model-thrift" -> "@guardian/content-atom-model",
+      "story-packages-model-thrift" -> "@guardian/story-packages-model"
+    ),
+    libraryDependencies ++= Seq(
+      "org.apache.thrift" % "libthrift" % "0.12.0",
+      "com.twitter" %% "scrooge-core" % "20.4.1",
+      "com.gu" % "story-packages-model-thrift" % "2.0.3",
+      "com.gu" % "content-atom-model-thrift" % "3.2.1",
+      "com.gu" % "content-entity-thrift" % "2.0.5"
+    )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,11 @@ lazy val typescript = (project in file("ts"))
     scroogeThriftSourceFolder in Compile := baseDirectory.value / "../models/src/main/thrift",
 
     scroogeTypescriptPackageLicense := "Apache-2.0",
-    scroogeThriftDependencies in Compile ++= Seq("content-entity-thrift"),
+    scroogeThriftDependencies in Compile ++= Seq(
+      "content-entity-thrift",
+      "content-atom-model-thrift",
+      "story-packages-model-thrift"
+    ),
     scroogeTypescriptPackageMapping := Map(
       "content-entity-thrift" -> "@guardian/content-entity-model",
       "content-atom-model-thrift" -> "@guardian/content-atom-model",

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -3,6 +3,7 @@ include "contentatom.thrift"
 include "entity.thrift"
 
 namespace scala com.gu.contentapi.client.model.v1
+#@namespace typescript _at_guardian.content_api_models.v1
 
 //include "atoms/quiz.thrift"
 

--- a/models/src/main/thrift/events/crier/event.thrift
+++ b/models/src/main/thrift/events/crier/event.thrift
@@ -1,4 +1,5 @@
 namespace scala com.gu.crier.model.event.v1
+#@namespace typescript _at_guardian.content_api_models.crier.event.v1
 
 include "content/v1.thrift"
 include "contentatom.thrift"

--- a/models/src/main/thrift/events/flexible/auxiliaryAtomEvent.thrift
+++ b/models/src/main/thrift/events/flexible/auxiliaryAtomEvent.thrift
@@ -1,4 +1,5 @@
 namespace scala com.gu.auxiliaryatom.model.auxiliaryatomevent.v1
+#@namespace typescript _at_guardian.content_api_models.auxiliaryatomevent.v1
 
 enum EventType {
     ADD = 0,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "19.9.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,8 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
+
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
+resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.1")


### PR DESCRIPTION
## What does this change?

- Upgrade the release pipeline
- Add support for typescript
- Update the readme

~This PR currently doesn't compile as it relies on the [yet-to-be-released story packages version](https://github.com/guardian/story-packages-model/pull/13).~ => released!
