### PR TITLE
Upgrade the typescript generation plugin.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,10 @@
 import sbt.Keys._
 import sbtrelease.ReleaseStateTransformations._
 
+val contentEntityVersion = "2.0.6"
+val contentAtomVersion = "3.2.2"
+val storyPackageVersion = "2.0.4"
+
 val mavenSettings = Seq(
   pomExtra := (
     <url>https://github.com/guardian/content-api-models</url>
@@ -131,9 +135,9 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.12.0",
       "com.twitter" %% "scrooge-core" % "20.4.1",
-      "com.gu" % "story-packages-model-thrift" % "2.0.3",
-      "com.gu" % "content-atom-model-thrift" % "3.2.1",
-      "com.gu" % "content-entity-thrift" % "2.0.5"
+      "com.gu" % "story-packages-model-thrift" % storyPackageVersion,
+      "com.gu" % "content-atom-model-thrift" % contentAtomVersion,
+      "com.gu" % "content-entity-thrift" % contentEntityVersion
     )
   )
 
@@ -189,8 +193,8 @@ lazy val typescript = (project in file("ts"))
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.12.0",
       "com.twitter" %% "scrooge-core" % "20.4.1",
-      "com.gu" % "story-packages-model-thrift" % "2.0.3",
-      "com.gu" % "content-atom-model-thrift" % "3.2.1",
-      "com.gu" % "content-entity-thrift" % "2.0.5"
+      "com.gu" % "story-packages-model-thrift" % storyPackageVersion,
+      "com.gu" % "content-atom-model-thrift" % contentAtomVersion,
+      "com.gu" % "content-entity-thrift" % contentEntityVersion
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.1")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")


### PR DESCRIPTION
It now publishes `.d.ts` files alongside the compiled `.js` files, rather than `.ts` and `.js` as it was initially set up.

This ensures the client project that consumes the NPM package doesn't get any compilation error coming from the generated library.

Before merging, I'll update the package version of:
 - [Content-entity](https://github.com/guardian/content-entity/pull/12) once this is merged
 - [Content-atom](https://github.com/guardian/content-atom/pull/141) once this is merged
 - [Story-packages](https://github.com/guardian/story-packages-model/pull/14) once this is merged
