### PR TITLE
Bring in updated atom model (with placeholderUrl)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbt.Keys._
 import sbtrelease.ReleaseStateTransformations._
 
 val contentEntityVersion = "2.0.6"
-val contentAtomVersion = "3.2.2"
+val contentAtomVersion = "3.2.4"
 val storyPackageVersion = "2.0.4"
 
 val mavenSettings = Seq(


### PR DESCRIPTION
Pull in the updated atom definitions that contain the placeholderUrl field.

See also: https://github.com/guardian/content-atom/pull/142 and https://github.com/guardian/content-api/pull/2520