### PR TITLE
Add a typed embed tracking status field to embed element.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ The content-api-models project builds the following bundles:
 
 * [@guardian/content-api-models](https://www.npmjs.com/package/@guardian/content-api-models) - An npm package containing the generated models and their type definitions.
 
+
+
+## Publishing locally 
+
+To publish a snapshot version locally.
+
+```
+sbt +publishLocal
+```

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -130,6 +130,7 @@ object CirceDecoders {
   implicit val entityDecoder = Decoder[Entity]
   implicit val entitiesResponseDecoder = Decoder[EntitiesResponse]
   implicit val pillarsResponseDecoder = Decoder[PillarsResponse]
+  implicit val embedTrackingDecoder = Decoder[EmbedTracking]
 
   // These two need to be written manually. I think the `Map[K, V]` type having 2 type params causes implicit divergence,
   // although shapeless's Lazy is supposed to work around that.

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -90,6 +90,7 @@ object CirceEncoders {
   implicit val atomsUsageResponseEncoder = Encoder[AtomUsageResponse]
   implicit val entitiesResponseEncoder = Encoder[EntitiesResponse]
   implicit val pillarsResponseEncoder = Encoder[PillarsResponse]
+  implicit val embedTrackingEncoder = Encoder[EmbedTracking]
 
   def genDateTimeEncoder(truncate: Boolean = true): Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>
     val dateTime: OffsetDateTime = OffsetDateTime.parse(capiDateTime.iso8601)

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -215,6 +215,12 @@ enum SponsorshipType {
     PAID_CONTENT = 2
 }
 
+enum EmbedTracksType {
+    UNKNOWN = 0,
+    TRACKS = 1,
+    DOES_NOT_TRACK = 2
+}
+
 struct Rights {
 
     1: optional bool syndicatable = false
@@ -630,6 +636,8 @@ struct EmbedElementFields {
     3: optional string alt
 
     4: optional bool isMandatory
+
+    5: optional EmbedTracking tracking
 }
 
 struct InstagramElementFields {
@@ -1885,3 +1893,6 @@ struct PillarsResponse {
     3: required list<Pillar> results
 }
 
+struct EmbedTracking {
+    1: required EmbedTracksType tracks = EmbedTracksType.UNKNOWN
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.9.3-SNAPSHOT"
+version in ThisBuild := "15.9.4"


### PR DESCRIPTION
## What does this change?

Adds an initial field to the embed element to document the tracking status of this 3rd party embed (if known).
This is a step towards the UI been able to ask the end user for informed concent before rending a potentially tracked embed.

Proposal: https://docs.google.com/document/d/1-6RWIHEUnjGHHvBCaXlhXy08RqAtmO_kJAnZXK5cv48


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Content api model is a public artefact.
Publishing this field potentially signals to outside parties that we have a concern in this area which we have not yet addressed.

## Images

<img width="225" alt="Screenshot 2020-11-13 at 09 26 37" src="https://user-images.githubusercontent.com/150238/99056564-5e270300-2592-11eb-9fb3-6fe430aa4a40.png">
