### PR TITLE
Element tracking field is promoted from embed element to all block elements

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -759,6 +759,11 @@ struct BlockElement {
 
     20: optional ContentAtomElementFields contentAtomTypeData
 
+    /*
+     * Optional field which may appear on a block element with a html field containing third party embed code.
+     * Likely to appear on embed and other rich media type elements.
+     * Does not appear on text block elements as the html field of a text element does not contain embed code.
+     */
     21: optional EmbedTracking tracking
 
 }

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -637,7 +637,6 @@ struct EmbedElementFields {
 
     4: optional bool isMandatory
 
-    5: optional EmbedTracking tracking
 }
 
 struct InstagramElementFields {
@@ -759,6 +758,8 @@ struct BlockElement {
     19: optional VineElementFields vineTypeData
 
     20: optional ContentAtomElementFields contentAtomTypeData
+
+    21: optional EmbedTracking tracking
 
 }
 


### PR DESCRIPTION
Optional field which will render of the element is deemed to potentially contain tracking embeds

<img width="702" alt="Screenshot 2020-11-18 at 10 40 36" src="https://user-images.githubusercontent.com/150238/99520607-33bab880-298b-11eb-9c42-16da49508da7.png">

Optional tracking field shown appearing on an embed and text element.


## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Promotes the track field for general use on all applicable block elements.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This field has never used in it's initial position under the embed element. Promoting it is considered safe.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->