### PR TITLE
Element role additions

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -430,6 +430,9 @@ struct AudioElementFields {
     9: optional bool clean
 
     10: optional bool explicit
+
+    11: optional string role
+
 }
 
 struct VideoElementFields {
@@ -625,6 +628,7 @@ struct MembershipElementFields {
     9: optional string price
     10: optional CapiDateTime start
     11: optional CapiDateTime end
+    12: optional string role
 }
 
 struct EmbedElementFields {
@@ -661,6 +665,8 @@ struct InstagramElementFields {
 
     9: optional string caption
 
+    10 : optional string role
+
 }
 
 struct CommentElementFields {
@@ -684,6 +690,9 @@ struct CommentElementFields {
     9: optional string authorName
 
     10: optional i32 commentId
+
+    11: optional string role
+
 }
 
 struct VineElementFields {
@@ -707,6 +716,8 @@ struct VineElementFields {
     9: optional string alt
 
     10: optional string caption
+
+    11: optional string role
 
 }
 

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -383,6 +383,9 @@ struct Asset {
 struct TextElementFields {
 
     1: optional string html
+
+    2: optional string role
+
 }
 
 struct PullquoteElementFields {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -637,6 +637,8 @@ struct EmbedElementFields {
 
     4: optional bool isMandatory
 
+    5: optional string role
+
 }
 
 struct InstagramElementFields {
@@ -714,8 +716,9 @@ struct ContentAtomElementFields {
 
   2: required string atomType
 
-}
+  3: optional string role
 
+}
 
 struct BlockElement {
 


### PR DESCRIPTION
## What does this change?

Adds the 'role' field to Block Element types which did not already have it; notably embed and atom.

As per: https://trello.com/c/cuA5lpWH/1290-embed-role-not-modelled-in-capi-block-element-view


## How to test

Adding a embed element in Composer should result in the role field appearing in the CAPI Block Element.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

This is a field addition. It should be safe.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
