### PR TITLE
New event to represent a successful content decache

### DIFF
--- a/models/src/main/thrift/events/fastly/event.thrift
+++ b/models/src/main/thrift/events/fastly/event.thrift
@@ -1,0 +1,28 @@
+namespace scala com.gu.fastly.model.event.v1
+#@namespace typescript _at_guardian.content_api_models.fastly.event.v1
+
+include "content/v1.thrift"
+
+enum EventType {
+    Update = 1,
+    Delete = 2,
+}
+
+struct ContentDecacheEvent {
+    1: required string contentId
+
+    2: required EventType eventType
+
+   /*
+    * The content type
+    * Convenience field to help consumers filter events
+    */
+    3: optional v1.ContentType contentType
+
+   /*
+    * If the content's URL has evolved over time, we include
+    * the aliasPaths so that e.g. de-caching can be comprehensively
+    * triggered when the content is updated
+    */
+    4: optional list<string> aliasPaths
+}

--- a/models/src/main/thrift/events/fastly/event.thrift
+++ b/models/src/main/thrift/events/fastly/event.thrift
@@ -8,7 +8,7 @@ enum EventType {
     Delete = 2,
 }
 
-struct ContentDecacheEvent {
+struct ContentDecachedEvent {
     1: required string contentId
 
     2: required EventType eventType


### PR DESCRIPTION
## What does this change?

Introduces an event to represent Fastly CDN decaches.

Includes some basic meta data which the consume may find useful.

Intended as a lightweight substitute of the crier Event which can be iterated on to better suit the decached content use case.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
