### PR TITLE
Deleted Content payload

### DIFF
--- a/models/src/main/thrift/events/crier/event.thrift
+++ b/models/src/main/thrift/events/crier/event.thrift
@@ -59,6 +59,20 @@ struct RetrievableContent {
     6: optional list<string> aliasPaths
 }
 
+/*
+* Until the advent of aliasPaths, we never needed to send a payload in delete events.
+* The DeletedContent struct enables us to include aliasPaths as a new kind of payload
+* and we decided that it would be sensible to express that in a future-expandable way
+* rather than create a new payload type specifically and only for aliasPaths
+ */
+struct DeletedContent {
+
+    /*
+    * The aliases associated with evolved URLs
+    */
+    1: optional list<string> aliasPaths
+}
+
 union EventPayload {
 
   1: v1.Content content
@@ -66,6 +80,8 @@ union EventPayload {
   2: RetrievableContent retrievableContent
 
   3: contentatom.Atom atom
+
+  4: DeletedContent deletedContent
 }
 
 struct Event {


### PR DESCRIPTION
## What does this change?

Provides a new type of content update payload to document the the optional alias paths of a piece of deleted content.

A content deleted update may start to provided this payload; currently content deleted events have no payload set.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
