### PR TITLE
Adding height and width to elements that can contain embedded content

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -397,6 +397,10 @@ struct PullquoteElementFields {
     3: optional string role
 
     4: optional string source
+
+    5: optional i32 height
+
+    6: optional i32 width
 }
 
 struct TweetElementFields {
@@ -412,6 +416,10 @@ struct TweetElementFields {
     5: optional string originalUrl
 
     6: optional string role
+
+    7: optional i32 height
+
+    8: optional i32 width
 }
 
 struct AudioElementFields {
@@ -437,6 +445,10 @@ struct AudioElementFields {
     10: optional bool explicit
 
     11: optional string role
+
+    12: optional i32 height
+
+    13: optional i32 width
 
 }
 
@@ -525,6 +537,8 @@ struct InteractiveElementFields {
     9: optional string iframeUrl
     10: optional string role
     11: optional bool isMandatory
+    12: optional i32 height
+    13: optional i32 width
 }
 
 struct StandardElementFields {
@@ -650,6 +664,10 @@ struct EmbedElementFields {
 
     6: optional string source
 
+    7: optional i32 height
+
+    8: optional i32 width
+
 }
 
 struct InstagramElementFields {
@@ -672,7 +690,9 @@ struct InstagramElementFields {
 
     9: optional string caption
 
-    10 : optional string role
+    10: optional string role
+
+    11: optional i32 height
 
 }
 


### PR DESCRIPTION
This change is part of the work to render a privacy 'overlay' for embedded content that requires the user to consent/click the overlay before the embed isloaded. 

To do this we need to have a correct size to render the overlay.

The height and width fields already exist in a lot of the element type data types, this change ensures all the element types that can contain embedded content have a height and width field.

## Have we considered potential risks?
This is an addition of an optional field so is low risk

