### PR TITLE
Reverting: Adding height and width to elements that can contain embedded content

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -398,7 +398,11 @@ struct PullquoteElementFields {
 
     4: optional string source
 
-    5: optional string sourceDomain
+//    5: optional i32 height
+
+//    6: optional i32 width
+
+    7: optional string sourceDomain
 }
 
 struct TweetElementFields {
@@ -415,7 +419,11 @@ struct TweetElementFields {
 
     6: optional string role
 
-    7: optional string sourceDomain
+//    7: optional i32 height
+
+//    8: optional i32 width
+
+    9: optional string sourceDomain
 }
 
 struct AudioElementFields {
@@ -442,7 +450,11 @@ struct AudioElementFields {
 
     11: optional string role
 
-    12: optional string sourceDomain
+//    12: optional i32 height
+
+//    13: optional i32 width
+
+    14: optional string sourceDomain
 }
 
 struct VideoElementFields {
@@ -532,7 +544,9 @@ struct InteractiveElementFields {
     9: optional string iframeUrl
     10: optional string role
     11: optional bool isMandatory
-    12: optional string sourceDomain
+//    12: optional i32 height
+//    13: optional i32 width
+    14: optional string sourceDomain
 }
 
 struct StandardElementFields {
@@ -660,7 +674,11 @@ struct EmbedElementFields {
 
     6: optional string source
 
-    7: optional string sourceDomain
+//    7: optional i32 height
+
+//    8: optional i32 width
+
+    9: optional string sourceDomain
 }
 
 struct InstagramElementFields {
@@ -685,7 +703,9 @@ struct InstagramElementFields {
 
     10: optional string role
 
-    11: optional string sourceDomain
+//    11: optional i32 height
+
+    12: optional string sourceDomain
 }
 
 struct CommentElementFields {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -398,11 +398,7 @@ struct PullquoteElementFields {
 
     4: optional string source
 
-    5: optional i32 height
-
-    6: optional i32 width
-
-    7: optional string sourceDomain
+    5: optional string sourceDomain
 }
 
 struct TweetElementFields {
@@ -419,11 +415,7 @@ struct TweetElementFields {
 
     6: optional string role
 
-    7: optional i32 height
-
-    8: optional i32 width
-
-    9: optional string sourceDomain
+    7: optional string sourceDomain
 }
 
 struct AudioElementFields {
@@ -450,11 +442,7 @@ struct AudioElementFields {
 
     11: optional string role
 
-    12: optional i32 height
-
-    13: optional i32 width
-
-    14: optional string sourceDomain
+    12: optional string sourceDomain
 }
 
 struct VideoElementFields {
@@ -544,9 +532,7 @@ struct InteractiveElementFields {
     9: optional string iframeUrl
     10: optional string role
     11: optional bool isMandatory
-    12: optional i32 height
-    13: optional i32 width
-    14: optional string sourceDomain
+    12: optional string sourceDomain
 }
 
 struct StandardElementFields {
@@ -674,11 +660,7 @@ struct EmbedElementFields {
 
     6: optional string source
 
-    7: optional i32 height
-
-    8: optional i32 width
-
-    9: optional string sourceDomain
+    7: optional string sourceDomain
 }
 
 struct InstagramElementFields {
@@ -703,9 +685,7 @@ struct InstagramElementFields {
 
     10: optional string role
 
-    11: optional i32 height
-
-    12: optional string sourceDomain
+    11: optional string sourceDomain
 }
 
 struct CommentElementFields {


### PR DESCRIPTION
This reverts the changes to add height and width to various element types.

https://github.com/guardian/content-api-models/pull/191

This change turned out not to be useful so its being removed to avoid unused clutter.
