### PR TITLE
Upgrade the thrift to ts compiler

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.6")


### PR DESCRIPTION
## What does this change?
This fixes a parsing bug for empty collections in the generated typescript code.

The issue was first spotted by the editions team, and investigated by @JamieB-gu and myself. See the fix [here](https://github.com/guardian/scrooge-extras/pull/13) for more informations.
