### PR TITLE
Content decached message clean up.

### DIFF
--- a/models/src/main/thrift/events/fastly/event.thrift
+++ b/models/src/main/thrift/events/fastly/event.thrift
@@ -9,7 +9,7 @@ enum EventType {
 }
 
 struct ContentDecachedEvent {
-    1: required string contentId
+    1: required string contentPath
 
     2: required EventType eventType
 
@@ -20,9 +20,10 @@ struct ContentDecachedEvent {
     3: optional v1.ContentType contentType
 
    /*
-    * If the content's URL has evolved over time, we include
-    * the aliasPaths so that e.g. de-caching can be comprehensively
-    * triggered when the content is updated
+    * Deprecated aliasPaths field.
+    * Content items which decache multiple paths should issue multiple decache messages
+    * Do not reuse this label number.
+    * 4: optional list<string> aliasPaths
     */
-    4: optional list<string> aliasPaths
+
 }


### PR DESCRIPTION
Rename content id to content path; as it is a path which Fastly has decached.

Retire the aliasPath field as content items which multiple paths will issue multiple decaches; consumers should react to each seperate decached path.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
