### PR TITLE
Platform types and embed reach model items

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -131,6 +131,7 @@ object CirceDecoders {
   implicit val entitiesResponseDecoder = Decoder[EntitiesResponse]
   implicit val pillarsResponseDecoder = Decoder[PillarsResponse]
   implicit val embedTrackingDecoder = Decoder[EmbedTracking]
+  implicit val embedReachDecoder = Decoder[EmbedReach]
 
   // These two need to be written manually. I think the `Map[K, V]` type having 2 type params causes implicit divergence,
   // although shapeless's Lazy is supposed to work around that.

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -91,6 +91,7 @@ object CirceEncoders {
   implicit val entitiesResponseEncoder = Encoder[EntitiesResponse]
   implicit val pillarsResponseEncoder = Encoder[PillarsResponse]
   implicit val embedTrackingEncoder = Encoder[EmbedTracking]
+  implicit val embedReachEncoder = Encoder[EmbedReach]
 
   def genDateTimeEncoder(truncate: Boolean = true): Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>
     val dateTime: OffsetDateTime = OffsetDateTime.parse(capiDateTime.iso8601)

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -221,6 +221,12 @@ enum EmbedTracksType {
     DOES_NOT_TRACK = 2
 }
 
+enum PlatformType {
+    WEB = 0,
+    AMP = 1,
+    APPS = 2
+}
+
 struct Rights {
 
     1: optional bool syndicatable = false

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1964,5 +1964,8 @@ struct PillarsResponse {
 
 struct EmbedTracking {
     1: required EmbedTracksType tracks = EmbedTracksType.UNKNOWN
-    2: optional list<PlatformType> unsupportedPlatforms
+}
+
+struct EmbedReach {
+    1: list<PlatformType> unsupportedPlatforms
 }

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1964,4 +1964,5 @@ struct PillarsResponse {
 
 struct EmbedTracking {
     1: required EmbedTracksType tracks = EmbedTracksType.UNKNOWN
+    2: optional list<PlatformType> unsupportedPlatforms
 }


### PR DESCRIPTION
## What does this change?

Introduce the Embed Reach struct which can be used to describe embed element reach / visibility on different platforms.

Introduce the PlatformTypes enum as a way to describe platforms; this is currently a subset of those used in Ohpan.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
