### PR TITLE
Add the ceasedToBeCanonicalAt datetime to evolved URL aliasPaths

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1518,6 +1518,13 @@ struct Debug {
     4: optional string originatingSystem
 }
 
+struct AliasPath {
+
+    1: required string path
+
+    2: required CapiDateTime ceasedToBeCanonicalAt
+}
+
 struct Content {
 
     /*
@@ -1646,7 +1653,13 @@ struct Content {
 
     25: optional string pillarName
 
-    26: optional list<string> aliasPaths
+    /* NOT USED
+     * aliasPaths as an optional list of string has been superceded
+     * by aliasPaths as an optional list of type AliasPath
+     */
+    //26: optional list<string> aliasPaths
+
+    27: optional list<AliasPath> aliasPaths
 }
 
 struct NetworkFront {

--- a/models/src/main/thrift/events/crier/event.thrift
+++ b/models/src/main/thrift/events/crier/event.thrift
@@ -56,7 +56,13 @@ struct RetrievableContent {
     * the aliasPaths so that e.g. de-caching can be comprehensively
     * triggered when the content is updated
     */
-    6: optional list<v1.AliasPath> aliasPaths
+
+    /* NOT USED
+     * aliasPaths is no longer a list<string>
+     */
+     //6: optional list<string> aliasPaths
+
+    7: optional list<v1.AliasPath> aliasPaths
 }
 
 /*
@@ -70,7 +76,12 @@ struct DeletedContent {
     /*
     * The aliases associated with evolved URLs
     */
-    1: optional list<v1.AliasPath> aliasPaths
+    /* NOT USED
+     * aliasPaths is no longer a list<string>>
+     */
+    //1: optional list<string> aliasPaths
+
+    2: optional list<v1.AliasPath> aliasPaths
 }
 
 union EventPayload {

--- a/models/src/main/thrift/events/crier/event.thrift
+++ b/models/src/main/thrift/events/crier/event.thrift
@@ -56,7 +56,7 @@ struct RetrievableContent {
     * the aliasPaths so that e.g. de-caching can be comprehensively
     * triggered when the content is updated
     */
-    6: optional list<string> aliasPaths
+    6: optional list<v1.AliasPath> aliasPaths
 }
 
 /*
@@ -70,7 +70,7 @@ struct DeletedContent {
     /*
     * The aliases associated with evolved URLs
     */
-    1: optional list<string> aliasPaths
+    1: optional list<v1.AliasPath> aliasPaths
 }
 
 union EventPayload {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.9.19-SNAPSHOT"
+version in ThisBuild := "15.10.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
Ophan require visibility of the date at which an alias ceased to reflect the canonical path for the content. This PR restructures the thrift model by removing the previous `string` representation and applies a new `AliasPath` type.

## How to test
Ensure that aliasPaths are properly represented in Concierge responses, capi scala client models, crier events, pubflow monitoring events and fastly decache events.

- [x] Tested on LOCAL environment (as much as possible)
- [ ] Tested on CODE environment

## How can we measure success?
The correct data appears in the correct places in the correct format? Success!

## Have we considered potential risks?
We're now changing more of the existing model but the feature isn't widely adopted yet, and because use of these are opt-in we don't imaging seeing any unexpected failures.

## Images
N/A
