### PR TITLE
Update thrift to 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,30 @@ project typescript
 releaseNpm <version> // you have to specify the version again i.e releaseNpm 1.0.0
 ```
 
+### Releasing SNAPSHOT or release candidate versions
+
+It's also possible to release a snapshot build to Sonatype's snapshot repo with no promotion to Maven Central. This can be useful for trialling a test or upgraded dependency internally.
+
+To do this, start sbt with a RELEASE_TYPE variable;
+
+`sbt -DRELEASE_TYPE=snapshot`
+
+Then, when you run `release cross`, you'll be asked to confirm that you intend to make a SNAPSHOT release, and if you proceed will be prompted to complete the snapshot version details. Whatever you specify here will be written back to the `version.sbt` but this won't be automatically committed back to github.
+
+You are able to re-release the same snapshot version repeatedly (which is handy if you're having GPG-related issues etc.)
+
+Making a release candidate is also possible by using the appropriate RELEASE_TYPE variable;
+
+`sbt -DRELEASE_TYPE=candidate`
+
+Here, the main differences are that the version number is expected to be of the format 1.2.3-RC1, and the release will be promoted to Maven Central. 
+
+As with the snapshot release process you'll be prompted to confirm and specify the version number you need to use, and changes applied to `version.sbt` will not be automatically committed to github etc.
+
+Unlike a production release, these alternatives are useful for testing/developing with another team or application and can be executed from a branch so there's no need to have everything merged into main/master branches prior to making your changes available.
+
+**Note:** `releaseNpm` also appears happy to accept non-production version numbers but may be less forgiving with re-publishing the same version number. This may require more effort if it becomes a problem.
+
 ## Information about built bundles
 
 The content-api-models project builds the following bundles: 

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import sbtrelease.ReleaseStateTransformations._
 val contentEntityVersion = "2.0.6"
 val contentAtomVersion = "3.2.4"
 val storyPackageVersion = "2.0.4"
+val thriftVersion = "0.14.1"
 
 val mavenSettings = Seq(
   pomExtra := (
@@ -133,7 +134,7 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
     },
     scroogePublishThrift in Compile := false,
     libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.12.0",
+      "org.apache.thrift" % "libthrift" % thriftVersion,
       "com.twitter" %% "scrooge-core" % "20.4.1",
       "com.gu" % "story-packages-model-thrift" % storyPackageVersion,
       "com.gu" % "content-atom-model-thrift" % contentAtomVersion,
@@ -191,7 +192,7 @@ lazy val typescript = (project in file("ts"))
       "story-packages-model-thrift" -> "@guardian/story-packages-model"
     ),
     libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.12.0",
+      "org.apache.thrift" % "libthrift" % thriftVersion,
       "com.twitter" %% "scrooge-core" % "20.4.1",
       "com.gu" % "story-packages-model-thrift" % storyPackageVersion,
       "com.gu" % "content-atom-model-thrift" % contentAtomVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtrelease.{Version, versionFormatError}
 val contentEntityVersion = "2.0.6"
 val contentAtomVersion = "3.2.4"
 val storyPackageVersion = "2.0.4"
-val thriftVersion = "0.14.1"
+val thriftVersion = "0.13.0"
 
 val candidateReleaseType = "candidate"
 val candidateReleaseSuffix = "-RC1"
@@ -56,7 +56,7 @@ val mavenSettings = Seq(
 )
 
 val versionSettingsMaybe = {
-  sys.props.get("releaseType").map {
+  sys.props.get("RELEASE_TYPE").map {
     case v if v == candidateReleaseType => candidateReleaseSuffix
     case v if v == snapshotReleaseType => snapshotReleaseSuffix
   }.map { suffix =>
@@ -78,7 +78,7 @@ val commonSettings = Seq(
 def customDeps(scalaVersion: String) = {
   val (circeVersion, diffsonVersion, fezziwigVersion) = CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, 11)) => ("0.11.0", "3.1.1", "1.2")
-    case _ => ("0.12.0", "4.0.0", "1.3")
+    case _ => ("0.12.0", "4.0.0", "1.4")
   }
   Seq(
     "com.gu" %% "fezziwig" % fezziwigVersion,
@@ -92,9 +92,9 @@ def customDeps(scalaVersion: String) = {
 
 /*
  Trialling being able to release snapshot versions from WIP branch without updating back to git
- e.g. $ sbt [-DreleaseType=snapshot|candidate] release cross
+ e.g. $ sbt [-DRELEASE_TYPE=snapshot|candidate] release cross
  or
-      $ sbt [-DreleaseType=snapshot|candidate]
+      $ sbt [-DRELEASE_TYPE=snapshot|candidate]
       sbt> release cross
       sbt> project typeScript
       sbt> releaseNpm <version>
@@ -142,7 +142,7 @@ val releaseProcessSteps: Seq[ReleaseStep] = {
   Release Candidate assemblies can be published to Sonatype and Maven.
 
   To make this work, start SBT with the candidate releaseType;
-    sbt -DreleaseType=candidate
+    sbt -DRELEASE_TYPE=candidate
 
   This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
 
@@ -157,8 +157,8 @@ val releaseProcessSteps: Seq[ReleaseStep] = {
     setNextVersion,
   )
 
-  // remember to set with sbt -DreleaseType=snapshot|candidate if running a non-prod release
-  commonSteps ++ (sys.props.get("releaseType") match {
+  // remember to set with sbt -DRELEASE_TYPE=snapshot|candidate if running a non-prod release
+  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
     case Some(v) if v == snapshotReleaseType => snapshotSteps // this deploys -SNAPSHOT build to sonatype snapshot repo only
     case Some(v) if v == candidateReleaseType => candidateSteps // this enables a release candidate build to sonatype and Maven
     case None => prodSteps  // our normal deploy route

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "16.0.0-RC3"
+version in ThisBuild := "16.0.0-RC4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "16.0.0-SNAPSHOT"
+version in ThisBuild := "16.0.0-RC2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "16.0.0-RC2"
+version in ThisBuild := "16.0.0-RC3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.10.3-SNAPSHOT"
+version in ThisBuild := "16.0.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
Snyk was starting to grumble about our thrift version, so we've updated it to `0.13.0` (this is the most compatible with our other dependencies at the moment).

## How to test
The plan would probably be to incorporate these models into e.g. [content-api-scala-client](https://github.com/guardian/content-api-scala-client) and run some tests with that. 

## How can we measure success?
Nothing falls apart or has tantrums? Success!

## Have we considered potential risks?
It might not work as expected, in which case we wouldn't release it as-is. We ought to be able to have locally built test releases that we can use to figure that out before it becomes a problem though.

## Images
![happy](https://user-images.githubusercontent.com/690395/114589387-8620ac80-9c7f-11eb-8da9-bc2e31ceca54.jpeg)

