### PR TITLE
removing bintray resolver as bintray is end of life

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.6")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.7-RC1")


### PR DESCRIPTION
This PR removes a bintray resolver as bintray is being retired.

Resolver details:

guardian - This was used for the sbt-scrooge-typescript which has been updated to a version that is available from maven central. (Wait for a full release)