### PR TITLE
Consume sbt-scrooge-typescript 1.3.0 from Maven

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.6")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "16.0.1-SNAPSHOT"
+version in ThisBuild := "16.1.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
Our sbt-scrooge-typescript sbt plugin is now published to Maven, so we should get it from there.

## How to test
I ran a release using the RC3 build of sbt-scrooge-typescript and subsequently released content-api-models 16.1.0-RC1 to Maven and the corresponding @guardian/content-api-models@16.1.0-RC1 to NPM (which I think is the step that relies on the plugin)

## How can we measure success?
The RC build reached NPM and looks complete (AFAICT) - https://www.npmjs.com/package/@guardian/content-api-models/v/16.1.0-RC1

## Have we considered potential risks?
Consumers may experience problems if there's anything wrong with the models, but updates can be made quite rapidly if there are any issues.

## Images
N/A

## Accessibility
N/A
