### PR TITLE
Import updated sbt-scrooge-typescript plugin 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Content API Thrift models
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models_2.12)
 [![Build Status](https://travis-ci.org/guardian/content-api-models.svg?branch=master)](https://travis-ci.org/guardian/content-api-models)
+
+## Version Info
+
+### 17.0.0 
+* This release imports the `sbt-scrooge-typescript 1.4.0` sbt plugin which has the potential to introduce some [breaking changes](https://github.com/apache/thrift/blob/master/CHANGES.md#breaking-changes-2) for generated typescript mappings via thrift 0.13.0, specifically related to the [handling of `Int64`](https://issues.apache.org/jira/browse/THRIFT-4675) data.
+
+## Releasing
 
 Ensure the version is composed of three parts (`1.2.3`) as NPM doesn't accept shorter versions such as `1.2`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Content API Thrift models
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models/badge.svg)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models)
 [![Build Status](https://travis-ci.org/guardian/content-api-models.svg?branch=master)](https://travis-ci.org/guardian/content-api-models)
 
 ## Version Info

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Content API Thrift models
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/content-api-models/badge.svg)
 [![Build Status](https://travis-ci.org/guardian/content-api-models.svg?branch=master)](https://travis-ci.org/guardian/content-api-models)
 
 ## Version Info

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.4.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "16.1.1-SNAPSHOT"
+version in ThisBuild := "16.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "16.2.0-SNAPSHOT"
+version in ThisBuild := "17.0.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
There's a newer version of the sbt-scrooge-typescript sbt plugin available (as a result of https://github.com/guardian/scrooge-extras/pull/18) which removes the last dependency on thrift `0.12.0`. We hope.

## How to test
This change should be invisible unless the updates in the plugin have unexpected side effects. I'll aim to release this as a release candidate build and test with the CAPI scala client. Apps Rendering may have to do the same to explore whether they have issues with Int64 conversions.

## How can we measure success?
If nobody finds anything wrong with the release candidate build we can proceed with a full release.

## Have we considered potential risks?
It's possible that clients may run into Int64 parsing problems but we ought to have enough test coverage to discover that quite quickly.

## Images
N/A

## Accessibility
N/A
