### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 /project/project/
 .idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install -g typescript
 
 It is worth noting that different teams follow different practices for model releases. In CAPI, we always release from master/main, so when you are happy with your local release, you can go ahead and make your PR. Once that is merged into main, you can publish your release to Maven. Two consecutive commits will automatically be made to master/main updating the next version number.
 
-### Releasing SNAPSHOT or release candidate versions
+### Releasing SNAPSHOT or beta versions
 
 It's also possible to release a snapshot build to Sonatype's snapshot repo with no promotion to Maven Central. This can be useful for trialling a test or upgraded dependency internally.
 
@@ -42,17 +42,17 @@ Then, when you run `release cross`, you'll be asked to confirm that you intend t
 
 You are able to re-release the same snapshot version repeatedly (which is handy if you're having GPG-related issues etc.)
 
-Making a release candidate is also possible by using the appropriate RELEASE_TYPE variable;
+Making a beta release is also possible by using the appropriate RELEASE_TYPE variable;
 
-`sbt -DRELEASE_TYPE=candidate`
+`sbt -DRELEASE_TYPE=beta`
 
-Here, the main differences are that the version number is expected to be of the format 1.2.3-RC1, and the release will be promoted to Maven Central. 
+Here, the main differences are that the version number is expected to be of the format 1.2.3-beta.n, and the release will be promoted to Maven Central. 
 
 As with the snapshot release process you'll be prompted to confirm and specify the version number you need to use, and changes applied to `version.sbt` will not be automatically committed to github etc.
 
 Unlike a production release, these alternatives are useful for testing/developing with another team or application and can be executed from a branch so there's no need to have everything merged into main/master branches prior to making your changes available.
 
-**Note:** `releaseNpm` also appears happy to accept non-production version numbers but may be less forgiving with re-publishing the same version number. This may require more effort if it becomes a problem.
+**Note:** `releaseNpm` (provided by our sbt-scrooge-typescript plugin) has been updated to apply a beta tag to the release, just be sure to use the `x.y.z-beta.n` version number format or NPM may reject it.
 
 ## Information about built bundles
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,21 @@ import sbt.Keys._
 import sbtrelease.ReleaseStateTransformations._
 import sbtrelease.{Version, versionFormatError}
 
-val contentEntityVersion = "2.2.0-beta.4"
-val contentAtomVersion = "3.4.0-beta.1"
-val storyPackageVersion = "2.2.0-beta.1"
+// dependency versions
+val contentEntityVersion = "2.2.1"
+val contentAtomVersion = "3.4.0"
+val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes
+val circeVersion = "0.14.1"
+val fezziwigVersion = "1.6"
 
+// dependency versions (for tests only)
+val scalaTestVersion = "3.0.8"
+val guavaVersion = "19.0"
+val diffsonVersion = "4.1.1"
+
+// support non-production release types
 val betaReleaseType = "beta"
 val betaReleaseSuffix = "-beta.0"
 val snapshotReleaseType = "snapshot"
@@ -84,21 +93,6 @@ lazy val commonSettings = Seq(
   licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   resolvers += Resolver.sonatypeRepo("public")
 ) ++ mavenSettings ++ versionSettingsMaybe
-
-def customDeps(scalaVersion: String) = {
-  val (circeVersion, diffsonVersion, fezziwigVersion) = CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, 11)) => ("0.11.0", "3.1.1", "1.2")
-    case _ => ("0.14.1", "4.1.1", "1.6")  // scala 2.12+
-  }
-  Seq(
-    "com.gu" %% "fezziwig" % fezziwigVersion,
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion,
-    "io.circe" %% "circe-optics" % circeVersion,
-    "org.gnieh" %% "diffson-circe" % diffsonVersion % "test"
-  )
-}
 
 /*
  Trialling being able to release snapshot versions from WIP branch without updating back to git
@@ -258,9 +252,15 @@ lazy val json = Project(id = "content-api-models-json", base = file("json"))
   .settings(
     description := "Json parser for the Guardian's Content API models",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-      "com.google.guava" % "guava" % "19.0" % "test"
-    ) ++ customDeps(scalaVersion.value),
+      "com.gu" %% "fezziwig" % fezziwigVersion,
+      "io.circe" %% "circe-core" % circeVersion,
+      "io.circe" %% "circe-generic" % circeVersion,
+      "io.circe" %% "circe-parser" % circeVersion,
+      "io.circe" %% "circe-optics" % circeVersion,
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      "com.google.guava" % "guava" % guavaVersion % "test",
+      "org.gnieh" %% "diffson-circe" % diffsonVersion % "test"
+    ),
     Compile / packageDoc / mappings := Nil
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtrelease.{Version, versionFormatError}
 val contentEntityVersion = "2.0.6"
 val contentAtomVersion = "3.2.4"
 val storyPackageVersion = "2.0.4"
-val thriftVersion = "0.13.0"
+val thriftVersion = "0.15.0"
 
 val candidateReleaseType = "candidate"
 val candidateReleaseSuffix = "-RC1"
@@ -45,6 +45,11 @@ lazy val mavenSettings = Seq(
         <id>annebyrne</id>
         <name>Anne Byrne</name>
         <url>https://github.com/annebyrne</url>
+      </developer>
+      <developer>
+        <id>justinpinner</id>
+        <name>Justin Pinner</name>
+        <url>https://github.com/justinpinner</url>
       </developer>
     </developers>
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,11 @@ import sbt.Keys._
 import sbtrelease.ReleaseStateTransformations._
 import sbtrelease.{Version, versionFormatError}
 
-val contentEntityVersion = "2.0.6"
-val contentAtomVersion = "3.2.4"
-val storyPackageVersion = "2.0.4"
+val contentEntityVersion = "2.1.0-RC2"
+val contentAtomVersion = "3.3.0-RC1"
+val storyPackageVersion = "2.1.0-RC1"
 val thriftVersion = "0.15.0"
+val scroogeVersion = "21.12.0"
 
 val candidateReleaseType = "candidate"
 val candidateReleaseSuffix = "-RC1"
@@ -46,7 +47,7 @@ lazy val mavenSettings = Seq(
         <name>Anne Byrne</name>
         <url>https://github.com/annebyrne</url>
       </developer>
-      <developer>
+       <developer>
         <id>justinpinner</id>
         <name>Justin Pinner</name>
         <url>https://github.com/justinpinner</url>
@@ -73,7 +74,11 @@ lazy val versionSettingsMaybe = {
 
 lazy val commonSettings = Seq(
   scalaVersion := "2.13.2",
-  crossScalaVersions := Seq("2.11.12", "2.12.11", scalaVersion.value),
+  // downgrade scrooge reserved word clashes to warnings
+  Compile / scroogeDisableStrict := true,
+  // scrooge 21.3.0: Builds are now only supported for Scala 2.12+
+  // https://twitter.github.io/scrooge/changelog.html#id11
+  crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   organization := "com.gu",
   licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -83,7 +88,7 @@ lazy val commonSettings = Seq(
 def customDeps(scalaVersion: String) = {
   val (circeVersion, diffsonVersion, fezziwigVersion) = CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, 11)) => ("0.11.0", "3.1.1", "1.2")
-    case _ => ("0.12.0", "4.0.0", "1.4")
+    case _ => ("0.14.1", "4.1.1", "1.6")  // scala 2.12+
   }
   Seq(
     "com.gu" %% "fezziwig" % fezziwigVersion,
@@ -237,7 +242,7 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
     Compile / scroogePublishThrift := false,
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % thriftVersion,
-      "com.twitter" %% "scrooge-core" % "20.4.1",
+      "com.twitter" %% "scrooge-core" % scroogeVersion,
       "com.gu" % "story-packages-model-thrift" % storyPackageVersion,
       "com.gu" % "content-atom-model-thrift" % contentAtomVersion,
       "com.gu" % "content-entity-thrift" % contentEntityVersion
@@ -295,7 +300,7 @@ lazy val typescript = (project in file("ts"))
     ),
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % thriftVersion,
-      "com.twitter" %% "scrooge-core" % "20.4.1",
+      "com.twitter" %% "scrooge-core" % scroogeVersion,
       "com.gu" % "story-packages-model-thrift" % storyPackageVersion,
       "com.gu" % "content-atom-model-thrift" % contentAtomVersion,
       "com.gu" % "content-entity-thrift" % contentEntityVersion

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtrelease.ReleaseStateTransformations._
 import sbtrelease.{Version, versionFormatError}
 
 val contentEntityVersion = "2.1.0-RC2"
-val contentAtomVersion = "3.3.0-RC1"
+val contentAtomVersion = "3.3.0-RC2"
 val storyPackageVersion = "2.1.0-RC1"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "21.12.0"

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -370,6 +370,7 @@ struct AssetFields {
 
   66: optional CapiDateTime start
 
+  /* `end` is a reserved word in scrooge, so use Compile / scroogeDisableStrict := true in build.sbt */
   67: optional CapiDateTime end
 
   68: optional bool safeEmbedCode
@@ -662,6 +663,7 @@ struct MembershipElementFields {
     8: optional string image
     9: optional string price
     10: optional CapiDateTime start
+    /* `end` is a reserved word in scrooge, so use Compile / scroogeDisableStrict := true in build.sbt */
     11: optional CapiDateTime end
     12: optional string role
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.12.0")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.4.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.6")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.12.0")
 addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.2.0-RC2"
+ThisBuild / version := "17.3.0-beta.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.3.0-beta.2"
+ThisBuild / version := "17.3.0-beta.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.1.2-SNAPSHOT"
+ThisBuild / version := "17.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.2.0-SNAPSHOT"
+ThisBuild / version := "17.2.0-RC2"


### PR DESCRIPTION
## What does this change?

Upgrade our dependencies and plugins to their latest available versions. This build brings in beta releases of some upstream libraries for testing while they have their own PRs open.

This branch was used to release the following builds;
[content-api-models-json 17.3.0-beta.2 for scala 2.12](https://repo1.maven.org/maven2/com/gu/content-api-models-json_2.12/17.3.0-beta.2/)
[content-api-models-json 17.3.0-beta.2 for scala 2.13](https://repo1.maven.org/maven2/com/gu/content-api-models-json_2.13/17.3.0-beta.2/)
[content-api-models 17.3.0-beta.2](https://repo1.maven.org/maven2/com/gu/content-api-models/17.3.0-beta.2/)
and
[@guardian/content-api-models 17.3.0-beta.2 for typescript](https://www.npmjs.com/package/@guardian/content-api-models/v/17.3.0-beta.2)

(note that the maven links above may take some time to appear)

## How to test

Testing the NPM build for vulnerabilities;
```
$ npm i @guardian/content-api-models@17.3.0-beta.2

added 15 packages, and audited 16 packages in 41s

found 0 vulnerabilities
```

## How can we measure success?

Consumers build and test cleanly? Success!

## Have we considered potential risks?

Risks should be minimal - it will require a specific action to incorporate this library into an application so nothing should inadvertently break (and we believe it's still fully functional anyway)

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
