### PR TITLE
Add initial channel structures

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1539,6 +1539,22 @@ struct AliasPath {
     2: required CapiDateTime ceasedToBeCanonicalAt
 }
 
+struct ChannelFields {
+
+    1: required bool isAvailable
+
+    2: optional CapiDateTime publicationDate
+
+}
+
+struct ContentChannel {
+
+    1: required string channelId
+
+    2: required ChannelFields fields
+
+}
+
 struct Content {
 
     /*
@@ -1674,6 +1690,12 @@ struct Content {
     //26: optional list<string> aliasPaths
 
     27: optional list<AliasPath> aliasPaths
+
+    /*
+    * Identifies which channel(s) this content is available in
+    */
+    28: optional list<ContentChannel> channels
+
 }
 
 struct NetworkFront {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.6.0-beta.2"
+ThisBuild / version := "17.6.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.4.1-SNAPSHOT"
+ThisBuild / version := "17.6.0-beta.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.3.1-SNAPSHOT"
+ThisBuild / version := "17.4.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Add the initial structures to support content channels. These will likely grow over time but for now, this is the minimum we need to get started.

## How to test

We'll build and release a local SNAPSHOT for local testing, then potentially make a beta release version for CODE testing before a final release for PROD.

Update:
Most recently released as `17.6.0-beta.1` to maven and npm. Have tested with that build.

## How can we measure success?

These effects will become visible in CAPI output at various points during testing.

## Have we considered potential risks?

Risk is very low. We're adding data so any consumers of prior versions will be none the wiser anyway.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable


