### PR TITLE
add tableofcontents to capi thrift model

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1178,6 +1178,8 @@ struct ContentFields {
     50: optional bool showAffiliateLinks
 
     51: optional string bylineHtml
+
+    52: optional bool showTableOfContents
 }
 
 struct Reference {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.4.1-SNAPSHOT"
+ThisBuild / version := "17.4.2-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR forms part of the process of adding the `showTableOfContents` Property to CAPI. In order to facilitate this and for it be consumed ultimately by the CAPI- Porter service, we need to publish a model.

## Testing
We have published a SNAPSHOT version to `Sonatype` - version: `17.4.1-SNAPSHOT` and tested this version in Concierge locally.

 ## Steps taken

1. content-api/elasticsearch: Add Table of Contents type to elasticsearch https://github.com/guardian/content-api/pull/2718
2. content-api/porter: Add Table of Contents field to porter https://github.com/guardian/content-api/pull/2719
3. content-api-models: Add Table of Contents to capi thrift model **(current PR)**
4. content-api/concierge: update content-api-models version to add Table of Contents in concierge - https://github.com/guardian/content-api/pull/2720
5 content-api-scala-client: Update capi model version - TO DO