### PR TITLE
Shadow isMandatory changes from flexible-model

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -432,6 +432,8 @@ struct TweetElementFields {
 //    8: optional i32 width
 
     9: optional string sourceDomain
+
+    10: optional bool isMandatory
 }
 
 struct AudioElementFields {
@@ -463,6 +465,8 @@ struct AudioElementFields {
 //    13: optional i32 width
 
     14: optional string sourceDomain
+
+    15: optional bool isMandatory
 }
 
 struct VideoElementFields {
@@ -506,6 +510,8 @@ struct VideoElementFields {
     19: optional string originalUrl
 
     20: optional string sourceDomain
+
+    21: optional bool isMandatory
 }
 
 struct ImageElementFields {
@@ -743,6 +749,8 @@ struct CommentElementFields {
 
     11: optional string role
 
+    12: optional bool isMandatory
+
 }
 
 struct VineElementFields {
@@ -780,6 +788,8 @@ struct ContentAtomElementFields {
   2: required string atomType
 
   3: optional string role
+
+  4: optional bool isMandatory
 
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.4.4-SNAPSHOT"
+ThisBuild / version := "17.5.0-beta.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.5.0-beta.1"
+ThisBuild / version := "17.5.1-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Adds `optional bool isMandatory` fields to
  * AudioElementFields
  * CommentElementFields
  * ContentAtomElementFields
  * TweetElementFields
  * VideoElementFields

This is to make us consistent with https://github.com/guardian/flexible-model/pull/54

## How to test

Output a [beta build](https://repo1.maven.org/maven2/com/gu/content-api-models-scala_2.13/17.5.0-beta.0/), consume and test in other applications.

I've imported the above beta build into Concierge and successfully ran all tests locally.

## How can we measure success?

If consuming applications don't fall apart with this version - success!

## Have we considered potential risks?

This is new data, so it shouldn't have unpleasant side effects for existing consumers.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] Not Applicable

