### PR TITLE
Bump content-atom version to 3.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtrelease.{Version, versionFormatError}
 
 // dependency versions
 val contentEntityVersion = "2.2.1"
-val contentAtomVersion = "3.4.0"
+val contentAtomVersion = "3.4.1"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes


### PR DESCRIPTION
## What does this change?

This bumps `content-atom` to 3.4.1. This version includes an optional youtube override image, only to be used in `media-atom-maker`. 