### PR TITLE
Add optional callout override fields

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -807,11 +807,11 @@ struct CalloutElementFields {
 
   2: optional bool isNonCollapsible
 
-  3: optional bool overridePrompt
+  3: optional string overridePrompt
 
-  4: optional bool overrideTitle
+  4: optional string overrideTitle
 
-  5: optional bool overrideDescription
+  5: optional string overrideDescription
 
 }
 

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -807,6 +807,12 @@ struct CalloutElementFields {
 
   2: optional bool isNonCollapsible
 
+  3 optional bool overridePrompt
+
+  4: optional bool overrideTitle
+
+  5: optional bool overrideDescription
+
 }
 
 struct BlockElement {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -807,7 +807,7 @@ struct CalloutElementFields {
 
   2: optional bool isNonCollapsible
 
-  3 optional bool overridePrompt
+  3: optional bool overridePrompt
 
   4: optional bool overrideTitle
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.6.1-SNAPSHOT"
+ThisBuild / version := "17.6.2-SNAPSHOT"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR updates the capi model to add the following optional overrides to the callout element type.

- overridePrompt
- overrideTitle
- overrideDescription

This PR is the fifth step of the work for updating the callout element in CAPI pipeline:
1. flexible-model: https://github.com/guardian/flexible-model/pull/55
2. flexible-content: https://github.com/guardian/flexible-content/pull/4233
3. content-api/elasticsearch: https://github.com/guardian/content-api/pull/2754
4. content-api/porter: https://github.com/guardian/content-api/pull/2755
5. **content-api-models**
6. content-api/concierge: https://github.com/guardian/content-api/pull/2756
7. content-api-scala-client: https://github.com/guardian/content-api-scala-client/pull/383
