### PR TITLE
Add isMandatory to AssetFields

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -375,6 +375,8 @@ struct AssetFields {
   67: optional CapiDateTime end
 
   68: optional bool safeEmbedCode
+
+  69: optional bool isMandatory
 }
 
 struct Asset {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

When we added extra `isMandatory` fields to [catch up with flexible-model](https://github.com/guardian/content-api-models/pull/218), I neglected to also add it to the generic `AssetFields` definition.

Without this in place, when block elements are pulled up to top-level elements in response to the `show-elements=` parameter being used, the top-level `elements` are missing the `isMandatory` data from their `assets`.

## How to test

-   [x]  Publish the change locally
-   [x]  Test with local Concierge
-   [ ]  Publish
-   [ ]  Repeat test on CODE

## How can we measure success?

Whenever block-level elements that contain `isMandatory` values in their associated `<elementType>TypeData` definition are promoted to top-level elements by `show-elements=`, the `isMandatory` data should be present in those elements.

## Have we considered potential risks?

This is new optional data. Clients updating to this version of models shouldn't be adversely affected if they are parsing the existing json or using thrift convertors.

## Images

Before;
```
            "elements": [
              {
                "type": "interactive",
                "assets": [
                  
                ],
                "interactiveTypeData": {
                  "originalUrl": "<path_to_an>/embed.html",
                  "source": "Guardian",
                  "alt": "Netflix subscriptions",
                  "scriptUrl": "<path_to_a>/boot.js",
                  "html": "<a href=\"<path_to_an>/embed.html\">Interactive</a>",
                  "scriptName": "iframe-wrapper",
                  "iframeUrl": "<path_to_an>/embed.html"
                }
              },
```


After;
```
            "elements": [
              {
                "type": "interactive",
                "assets": [
                  
                ],
                "interactiveTypeData": {
                  "originalUrl": "<path_to_an>/embed.html",
                  "source": "Guardian",
                  "alt": "Netflix subscriptions",
                  "scriptUrl": "<path_to_a>/boot.js",
                  "html": "<a href=\"<path_to_an>/embed.html\">Interactive</a>",
                  "scriptName": "iframe-wrapper",
                  "iframeUrl": "<path_to_an>/embed.html",
                  "isMandatory": false
                }
              },
```


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] Not Applicable
