### PR TITLE
Add cartoon to content model

### DIFF
--- a/json/src/test/resources/templates/item-content-with-blocks.json
+++ b/json/src/test/resources/templates/item-content-with-blocks.json
@@ -24,7 +24,8 @@
         "comments":0,
         "instagram":0,
         "vines":0,
-        "callouts":0
+        "callouts":0,
+        "cartoons": 1
       },
       "blocks": {
         "main": {
@@ -146,6 +147,32 @@
                   "imageType":"Photograph"
                 },
                 "type": "image"
+              },
+              {
+                "assets": [],
+                "cartoonTypeData": {
+                  "variants": [
+                    {
+                      "viewportSize": "large",
+                      "images": [
+                        {
+                          "mimeType": "image/jpeg",
+                          "file": "https://api.media.test.dev-gutools.co.uk/images/75a4d4caaadaaf021c2dc6d4890b1524ef80b017",
+                          "width": 4129,
+                          "height": 1254,
+                          "mediaId": "75a4d4caaadaaf021c2dc6d4890b1524ef80b017"
+                        }
+                      ]
+                    }
+                  ],
+                  "role": "showcase",
+                  "credit":"Simone Lia",
+                  "caption": "The Mary Poppins Method",
+                  "alt": "The Mary Poppins Method",
+                  "source": "The Observer",
+                  "displayCredit": true
+                },
+                "type": "cartoon"
               }
           ]
         }, {

--- a/json/src/test/resources/templates/item-content-with-blocks.json
+++ b/json/src/test/resources/templates/item-content-with-blocks.json
@@ -165,11 +165,13 @@
                     }
                   ],
                   "role": "showcase",
-                  "credit":"Simone Lia",
+                  "photographer":"Simone Lia",
                   "caption": "The Mary Poppins Method",
                   "alt": "The Mary Poppins Method",
                   "source": "The Observer",
-                  "displayCredit": true
+                  "displayCredit": true,
+                  "imageType": "Illustration",
+                  "credit": "Illustration: Simone Lia/The Observer"
                 },
                 "type": "cartoon"
               }

--- a/json/src/test/resources/templates/item-content-with-blocks.json
+++ b/json/src/test/resources/templates/item-content-with-blocks.json
@@ -24,8 +24,7 @@
         "comments":0,
         "instagram":0,
         "vines":0,
-        "callouts":0,
-        "cartoons": 1
+        "callouts":0
       },
       "blocks": {
         "main": {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -381,7 +381,7 @@ struct AssetFields {
 
   69: optional bool isMandatory
 
-  70: optional list<CartoonVariant> variants
+  70: optional list<CartoonVariant> cartoonVariants
 }
 
 struct Asset {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -838,6 +838,9 @@ struct CartoonElementFields {
 
     7: optional bool displayCredit;
 
+    8: optional string photographer;
+
+    9: optional string imageType;
 }
 
 struct CartoonVariant {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1601,7 +1601,10 @@ struct ContentStats {
 
     15: required i32 callouts
 
-    16: required i32 cartoons
+    /*
+    * TODO: add cartoons stat when ready for final release
+    * 16: required i32 cartoons
+    */
 }
 
 struct Debug {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -142,6 +142,8 @@ enum ElementType {
 
     CALLOUT = 20
 
+    CARTOON = 21
+
 }
 
 enum TagType {
@@ -202,7 +204,8 @@ enum AssetType {
     VIDEO = 1,
     AUDIO = 2,
     EMBED = 3,
-    TWEET = 4
+    TWEET = 4,
+    CARTOON = 5
 }
 
 enum MembershipTier {
@@ -377,6 +380,8 @@ struct AssetFields {
   68: optional bool safeEmbedCode
 
   69: optional bool isMandatory
+
+  70: optional list<CartoonVariant> variants
 }
 
 struct Asset {
@@ -817,6 +822,45 @@ struct CalloutElementFields {
 
 }
 
+struct CartoonElementFields {
+
+    1: optional list<CartoonVariant> variants;
+
+    2: optional string role;
+
+    3: optional string credit;
+
+    4: optional string caption;
+
+    5: optional string alt;
+
+    6: optional string source;
+
+    7: optional bool displayCredit;
+
+}
+
+struct CartoonVariant {
+
+    1: required string viewportSize;
+
+    2: required list<CartoonImage> images;
+
+}
+
+struct CartoonImage {
+
+    1: required string mimeType;
+
+    2: required string file;
+
+    3: optional i32 width;
+
+    4: optional i32 height;
+
+    5: optional string mediaId;
+}
+
 struct BlockElement {
 
     1: required ElementType type
@@ -869,6 +913,8 @@ struct BlockElement {
     22: optional CodeElementFields codeTypeData
 
     23: optional CalloutElementFields calloutTypeData
+
+    24: optional CartoonElementFields cartoonTypeData
 
 }
 
@@ -1554,6 +1600,8 @@ struct ContentStats {
     14: required i32 vines
 
     15: required i32 callouts
+
+    16: required i32 cartoons
 }
 
 struct Debug {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.6.4-SNAPSHOT"
+ThisBuild / version := "17.7.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
This adds the cartoon element to the CAPI model. Follows on from:

https://github.com/guardian/flexible-model/pull/58
https://github.com/guardian/content-api/pull/2769
https://github.com/guardian/content-api/pull/2770

## How to test

The tests have been updated in `content-api-models-json`. To run:

```
sbt
[>](sbt:root>) ++2.12.11
[>](sbt:root>) test
```
