### PR TITLE
Add category to the Asset field

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -377,6 +377,8 @@ struct AssetFields {
   68: optional bool safeEmbedCode
 
   69: optional bool isMandatory
+
+  70: optional string category
 }
 
 struct Asset {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "17.6.4-SNAPSHOT"
+ThisBuild / version := "17.7.5-SNAPSHOT"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds an optional Category to the `AssetFields`, this is to support the category added to the media atom so that we can show it in DCR in the video 'pill'.

The category is already supported in the [media-atom-model](https://github.com/guardian/content-atom/blob/master/thrift/src/main/thrift/atoms/media.thrift#L99)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Other related PRs
- **content-api-models (this one)**
- content-api-scala-client: https://github.com/guardian/content-api-scala-client/pull/389
- frontend: https://github.com/guardian/frontend/pull/26316
- frontend: https://github.com/guardian/frontend/pull/26317
- DCR: https://github.com/guardian/dotcom-rendering/pull/8277

## Testing
This has all been tested locally with snapshots

