### PR TITLE
Add list element

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -98,7 +98,7 @@ object CirceDecoders {
   implicit val assetDecoder = Decoder[Asset]
   implicit val elementDecoder = Decoder[Element]
   implicit val referenceDecoder = Decoder[Reference]
-  implicit val blockElementDecoder = Decoder[BlockElement]
+  implicit val blockElementDecoder: Decoder[BlockElement] = shapeless.cachedImplicit
   implicit val blockDecoder = Decoder[Block]
   implicit val blocksDecoder = genBlocksDecoder
   implicit val rightsDecoder = Decoder[Rights]

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -42,6 +42,7 @@ object CirceEncoders {
     Json.fromFields(fields)
   }
 
+  implicit val blockElementEncoder: Encoder[BlockElement] = shapeless.cachedImplicit
   implicit val networkFrontEncoder = Encoder[NetworkFront]
   implicit val dateTimeEncoder = genDateTimeEncoder()
   implicit val contentFieldsEncoder = Encoder[ContentFields]

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -44,7 +44,7 @@ object CirceEncoders {
 
   implicit val blockElementEncoder: Encoder[BlockElement] = shapeless.cachedImplicit
   implicit val networkFrontEncoder = Encoder[NetworkFront]
-  implicit val dateTimeEncoder = genDateTimeEncoder()
+  implicit val dateTimeEncoder: Encoder[CapiDateTime] = genDateTimeEncoder()
   implicit val contentFieldsEncoder = Encoder[ContentFields]
   implicit val editionEncoder = Encoder[Edition]
   implicit val sponsorshipEncoder = Encoder[Sponsorship]

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -145,6 +145,8 @@ enum ElementType {
     CARTOON = 21
 
     RECIPE = 22
+
+    LIST = 23
 }
 
 enum TagType {
@@ -869,6 +871,26 @@ struct RecipeElementFields {
     1: optional string recipeJson;
 }
 
+enum ListType {
+    KEY_TAKEAWAYS = 1,
+    Q_AND_A_EXPLAINER = 2,
+}
+
+struct ListItem {
+
+    1: required list<BlockElement> elements = [];
+
+    2: optional string title;
+
+}
+
+struct ListElementFields {
+
+    1: required list<ListItem> items;
+    
+    2: optional ListType type;
+}
+
 struct BlockElement {
 
     1: required ElementType type
@@ -925,6 +947,8 @@ struct BlockElement {
     24: optional CartoonElementFields cartoonTypeData
 
     25: optional RecipeElementFields recipeTypeData
+
+    26: optional ListElementFields listTypeData
 }
 
 struct MembershipPlaceholder {


### PR DESCRIPTION
## What does this change?

Adds a new element type `List` which will be used to provide more structure around existing formats such as Key Takeaways.

This block element is novel in that it also contains block element, creating a recursive data structure. It is not currently anticipated that a `List` element will contain `List` elements, although there is no easy way to prevent this in the thrift definition.

The recursion did cause problems with Fezziwig's auto serialisation, which we have worked around by explicitly caching the serialisers for BlockElement. It is possible that we will change our approach here following work on Fezziwig itself by Emily Bourke.

## How to test

Run tests, they should pass.

publishLocal and try building/testing content-api-scala-client and content-api with this library.
- [x] concierge
- [x] content-api-scala-client 
