### PR TITLE
Add optional sponsorship package field

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -220,6 +220,12 @@ enum SponsorshipType {
     PAID_CONTENT = 2
 }
 
+enum SponsorshipPackage {
+    DEFAULT = 0,
+    US = 1,
+    US_EXCLUSIVE = 2
+}
+
 enum EmbedTracksType {
     UNKNOWN = 0,
     TRACKS = 1,
@@ -656,6 +662,7 @@ struct Sponsorship {
 
     11: optional CapiDateTime validTo
 
+    12: optional SponsorshipPackage sponsorshipPackage
 }
 
 struct RichLinkElementFields {


### PR DESCRIPTION
## What does this change?

Adds a new field for sponsorship package.  More information in https://github.com/guardian/tagmanager/pull/508

Virtually identical change to tags-thrift-schema - https://github.com/guardian/tags-thrift-schema/pull/43