### PR TITLE
Recipe schema org thrift

### DIFF
--- a/models/src/main/thrift/content/schema_org.thrift
+++ b/models/src/main/thrift/content/schema_org.thrift
@@ -1,6 +1,9 @@
 namespace scala com.gu.contentapi.client.model.schemaorg
 #@namespace typescript _at_guardian.content_api_models.schemaorg
 
+struct SchemaOrg {
+    1: optional list<SchemaRecipe> recipe
+}
 
 struct SchemaRecipe {
     1: required string _at_context

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1,7 +1,7 @@
 include "story_package_article.thrift"
 include "contentatom.thrift"
 include "entity.thrift"
-include "schemaorg.thrift"
+include "schema_org.thrift"
 
 namespace scala com.gu.contentapi.client.model.v1
 #@namespace typescript _at_guardian.content_api_models.v1
@@ -1684,10 +1684,6 @@ struct ContentChannel {
 
 }
 
-struct SchemaOrg {
-    1: optional list<schemaorg.SchemaRecipe> recipe
-}
-
 struct Content {
 
     /*
@@ -1832,7 +1828,7 @@ struct Content {
     /*
     * Schema.org compatible data
      */
-    29: optional SchemaOrg schemaOrg
+    29: optional schema_org.SchemaOrg schemaOrg
 }
 
 struct NetworkFront {


### PR DESCRIPTION
The first step in finally getting recipe schema onto the Guardian website and reaping the SEO benefits. This PR adds a Thrift definition for Schema.org recipes.

Companions downstream: 

- https://github.com/guardian/content-api-scala-client/pull/408
- https://github.com/guardian/content-api/pull/2858
- https://github.com/guardian/facia-scala-client/pull/310
- https://github.com/guardian/frontend/pull/26931

For more information on the fields included see https://schema.org/Recipe.

Preview deployed via https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md#choose-release-type