### PR TITLE
Update fezziwig to v2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes
 val circeVersion = "0.14.1"
-val fezziwigVersion = "1.6"
+val fezziwigVersion = "2.0.0"
 
 // dependency versions (for tests only)
 val scalaTestVersion = "3.0.8"

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -1,11 +1,17 @@
 package com.gu.contentapi.json
 
 import io.circe._
-import com.gu.contentatom.thrift.{Atom, AtomData, AtomType}
-import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, decodeThriftUnion}
+import io.circe.generic.semiauto._
 import com.gu.contentapi.client.model.v1._
+import com.gu.contentapi.client.model.schemaorg.{SchemaOrg, SchemaRecipe, AuthorInfo, RecipeStep}
+import com.gu.contentatom.thrift.atom._
+import com.gu.contentatom.{thrift => contentatom}
+import com.gu.contententity.thrift.entity._
+import com.gu.contententity.{thrift => contententity}
+import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum}
+import com.gu.fezziwig.CirceScroogeWhiteboxMacros._
+import com.gu.storypackage.model.{v1 => storypackage}
 import cats.syntax.either._
-import com.gu.contententity.thrift.Entity
 import java.time.OffsetDateTime
 import java.time.chrono.IsoChronology
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, ResolverStyle}
@@ -91,47 +97,148 @@ object CirceDecoders {
 
   // The following implicits technically shouldn't be necessary
   // but stuff doesn't compile without them
-  implicit val contentFieldsDecoder = Decoder[ContentFields]
-  implicit val editionDecoder = Decoder[Edition]
-  implicit val sponsorshipDecoder = Decoder[Sponsorship]
-  implicit val tagDecoder = Decoder[Tag]
-  implicit val assetDecoder = Decoder[Asset]
-  implicit val elementDecoder = Decoder[Element]
-  implicit val referenceDecoder = Decoder[Reference]
-  implicit val blockElementDecoder: Decoder[BlockElement] = shapeless.cachedImplicit
-  implicit val blockDecoder = Decoder[Block]
-  implicit val blocksDecoder = genBlocksDecoder
-  implicit val rightsDecoder = Decoder[Rights]
-  implicit val crosswordEntryDecoder = genCrosswordEntryDecoder
-  implicit val crosswordDecoder = Decoder[Crossword]
-  implicit val contentStatsDecoder = Decoder[ContentStats]
-  implicit val sectionDecoder = Decoder[Section]
-  implicit val debugDecoder = Decoder[Debug]
-  implicit val atomTypeDecoder = Decoder[AtomType]
-  implicit val atomDataDecoder = Decoder[AtomData]
-  implicit val atomDecoder = Decoder[Atom]
-  implicit val atomsDecoder = Decoder[Atoms]
-  implicit val pillarDecoder = Decoder[Pillar]
-  implicit val contentDecoder = Decoder[Content]
-  implicit val mostViewedVideoDecoder = Decoder[MostViewedVideo]
-  implicit val networkFrontDecoder = Decoder[NetworkFront]
-  implicit val packageArticleDecoder = Decoder[PackageArticle]
-  implicit val packageDecoder = Decoder[Package]
-  implicit val itemResponseDecoder = Decoder[ItemResponse]
-  implicit val searchResponseDecoder = Decoder[SearchResponse]
-  implicit val editionsResponseDecoder = Decoder[EditionsResponse]
-  implicit val tagsResponseDecoder = Decoder[TagsResponse]
-  implicit val sectionsResponseDecoder = Decoder[SectionsResponse]
-  implicit val atomsResponseDecoder = Decoder[AtomsResponse]
-  implicit val packagesResponseDecoder = Decoder[PackagesResponse]
-  implicit val errorResponseDecoder = Decoder[ErrorResponse]
-  implicit val videoStatsResponseDecoder = Decoder[VideoStatsResponse]
-  implicit val atomsUsageResponseDecoder = Decoder[AtomUsageResponse]
-  implicit val entityDecoder = Decoder[Entity]
-  implicit val entitiesResponseDecoder = Decoder[EntitiesResponse]
-  implicit val pillarsResponseDecoder = Decoder[PillarsResponse]
-  implicit val embedTrackingDecoder = Decoder[EmbedTracking]
-  implicit val embedReachDecoder = Decoder[EmbedReach]
+  implicit val contentFieldsDecoder: Decoder[ContentFields] = deriveDecoder
+  implicit val editionDecoder: Decoder[Edition] = deriveDecoder
+  implicit val sponsorshipDecoder: Decoder[Sponsorship] = deriveDecoder
+  implicit val sponsorshipTargetingDecoder: Decoder[SponsorshipTargeting] = deriveDecoder
+  implicit val sponsorshipLogoDimensionsDecoder: Decoder[SponsorshipLogoDimensions] = deriveDecoder
+  implicit val tagDecoder: Decoder[Tag] = deriveDecoder
+  implicit val podcastDecoder: Decoder[Podcast] = deriveDecoder
+  implicit val podcastCategoryDecoder: Decoder[PodcastCategory] = deriveDecoder
+  implicit val assetDecoder: Decoder[Asset] = deriveDecoder
+  implicit val assetFieldsDecoder: Decoder[AssetFields] = deriveDecoder
+  implicit val cartoonVariantDecoder: Decoder[CartoonVariant] = deriveDecoder
+  implicit val cartoonImageDecoder: Decoder[CartoonImage] = deriveDecoder
+  implicit val elementDecoder: Decoder[Element] = deriveDecoder
+  implicit val referenceDecoder: Decoder[Reference] = deriveDecoder
+  implicit val blockElementDecoder: Decoder[BlockElement] = deriveDecoder
+  implicit val textElementFieldsDecoder: Decoder[TextElementFields] = deriveDecoder
+  implicit val videoElementFieldsDecoder: Decoder[VideoElementFields] = deriveDecoder
+  implicit val tweetElementFieldsDecoder: Decoder[TweetElementFields] = deriveDecoder
+  implicit val imageElementFieldsDecoder: Decoder[ImageElementFields] = deriveDecoder
+  implicit val audioElementFieldsDecoder: Decoder[AudioElementFields] = deriveDecoder
+  implicit val pullquoteElementFieldsDecoder: Decoder[PullquoteElementFields] = deriveDecoder
+  implicit val interactiveElementFieldsDecoder: Decoder[InteractiveElementFields] = deriveDecoder
+  implicit val standardElementFieldsDecoder: Decoder[StandardElementFields] = deriveDecoder
+  implicit val witnessElementFieldsDecoder: Decoder[WitnessElementFields] = deriveDecoder
+  implicit val richLinkElementFieldsDecoder: Decoder[RichLinkElementFields] = deriveDecoder
+  implicit val membershipElementFieldsDecoder: Decoder[MembershipElementFields] = deriveDecoder
+  implicit val embedElementFieldsDecoder: Decoder[EmbedElementFields] = deriveDecoder
+  implicit val instagramElementFieldsDecoder: Decoder[InstagramElementFields] = deriveDecoder
+  implicit val commentElementFieldsDecoder: Decoder[CommentElementFields] = deriveDecoder
+  implicit val vineElementFieldsDecoder: Decoder[VineElementFields] = deriveDecoder
+  implicit val contentAtomElementFieldsDecoder: Decoder[ContentAtomElementFields] = deriveDecoder
+  implicit val embedTrackingDecoder: Decoder[EmbedTracking] = deriveDecoder
+  implicit val codeElementFieldsDecoder: Decoder[CodeElementFields] = deriveDecoder
+  implicit val calloutElementFieldsDecoder: Decoder[CalloutElementFields] = deriveDecoder
+  implicit val cartoonElementFieldsDecoder: Decoder[CartoonElementFields] = deriveDecoder
+  implicit val recipeElementFieldsDecoder: Decoder[RecipeElementFields] = deriveDecoder
+  implicit val listElementFieldsDecoder: Decoder[ListElementFields] = deriveDecoder
+  implicit val listItemDecoder: Decoder[ListItem] = deriveDecoder
+  implicit val timelineElementFieldsDecoder: Decoder[TimelineElementFields] = deriveDecoder
+  implicit val timelineSectionDecoder: Decoder[TimelineSection] = deriveDecoder
+  implicit val timelineEventDecoder: Decoder[TimelineEvent] = deriveDecoder
+  implicit val blockDecoder: Decoder[Block] = deriveDecoder
+  implicit val blockAttributesDecoder: Decoder[BlockAttributes] = deriveDecoder
+  implicit val membershipPlaceholderDecoder: Decoder[MembershipPlaceholder] = deriveDecoder
+  implicit val userDecoder: Decoder[User] = deriveDecoder
+  implicit val blocksDecoder: Decoder[Blocks] = genBlocksDecoder
+  implicit val rightsDecoder: Decoder[Rights] = deriveDecoder
+  implicit val crosswordEntryDecoder: Decoder[CrosswordEntry] = genCrosswordEntryDecoder
+  implicit val crosswordPositionDecoder: Decoder[CrosswordPosition] = deriveDecoder
+  implicit val crosswordDecoder: Decoder[Crossword] = deriveDecoder
+  implicit val crosswordDimensionsDecoder: Decoder[CrosswordDimensions] = deriveDecoder
+  implicit val crosswordCreatorDecoder: Decoder[CrosswordCreator] = deriveDecoder
+  implicit val contentStatsDecoder: Decoder[ContentStats] = deriveDecoder
+  implicit val sectionDecoder: Decoder[Section] = deriveDecoder
+  implicit val debugDecoder: Decoder[Debug] = deriveDecoder
+  implicit val atomDataDecoder: Decoder[contentatom.AtomData] = deriveDecoder
+  implicit val quizAtomDecoder: Decoder[quiz.QuizAtom] = deriveDecoder
+  implicit val quizContentDecoder: Decoder[quiz.QuizContent] = deriveDecoder
+  implicit val questionDecoder: Decoder[quiz.Question] = deriveDecoder
+  implicit val answerDecoder: Decoder[quiz.Answer] = deriveDecoder
+  implicit val quizAssetDecoder: Decoder[quiz.Asset] = deriveDecoder
+  implicit val resultGroupsDecoder: Decoder[quiz.ResultGroups] = deriveDecoder
+  implicit val resultGroupDecoder: Decoder[quiz.ResultGroup] = deriveDecoder
+  implicit val resultBucketsDecoder: Decoder[quiz.ResultBuckets] = deriveDecoder
+  implicit val resultBucketDecoder: Decoder[quiz.ResultBucket] = deriveDecoder
+  implicit val mediaAtomDecoder: Decoder[media.MediaAtom] = deriveDecoder
+  implicit val imageDecoder: Decoder[contentatom.Image] = deriveDecoder
+  implicit val imageAssetDecoder: Decoder[contentatom.ImageAsset] = deriveDecoder
+  implicit val imageAssetDimensionsDecoder: Decoder[contentatom.ImageAssetDimensions] = deriveDecoder
+  implicit val mediaAssetDecoder: Decoder[media.Asset] = deriveDecoder
+  implicit val mediaMetadataDecoder: Decoder[media.Metadata] = deriveDecoder
+  implicit val mediaPlutoDataDecoder: Decoder[media.PlutoData] = deriveDecoder
+  implicit val mediaYoutubeDataDecoder: Decoder[media.YoutubeData] = deriveDecoder
+  implicit val explainerAtomDecoder: Decoder[explainer.ExplainerAtom] = deriveDecoder
+  implicit val ctaAtomDecoder: Decoder[cta.CTAAtom] = deriveDecoder
+  implicit val interactiveAtomDecoder: Decoder[interactive.InteractiveAtom] = deriveDecoder
+  implicit val reviewAtomDecoder: Decoder[review.ReviewAtom] = deriveDecoder
+  implicit val ratingDecoder: Decoder[review.Rating] = deriveDecoder
+  implicit val restaurantDecoder: Decoder[restaurant.Restaurant] = deriveDecoder
+  implicit val addressDecoder: Decoder[contententity.Address] = deriveDecoder
+  implicit val geolocationDecoder: Decoder[contententity.Geolocation] = deriveDecoder
+  implicit val gameDecoder: Decoder[game.Game] = deriveDecoder
+  implicit val priceDecoder: Decoder[contententity.Price] = deriveDecoder
+  implicit val filmDecoder: Decoder[film.Film] = deriveDecoder
+  implicit val personDecoder: Decoder[person.Person] = deriveDecoder
+  implicit val qAndAAtomDecoder: Decoder[qanda.QAndAAtom] = deriveDecoder
+  implicit val qAndAItemDecoder: Decoder[qanda.QAndAItem] = deriveDecoder
+  implicit val guideAtomDecoder: Decoder[guide.GuideAtom] = deriveDecoder
+  implicit val guideItemDecoder: Decoder[guide.GuideItem] = deriveDecoder
+  implicit val profileAtomDecoder: Decoder[profile.ProfileAtom] = deriveDecoder
+  implicit val profileItemDecoder: Decoder[profile.ProfileItem] = deriveDecoder
+  implicit val timelineAtomDecoder: Decoder[timeline.TimelineAtom] = deriveDecoder
+  implicit val timelineItemDecoder: Decoder[timeline.TimelineItem] = deriveDecoder
+  implicit val commonsDivisionDecoder: Decoder[commonsdivision.CommonsDivision] = deriveDecoder
+  implicit val votesDecoder: Decoder[commonsdivision.Votes] = deriveDecoder
+  implicit val mpDecoder: Decoder[commonsdivision.Mp] = deriveDecoder
+  implicit val chartAtomDecoder: Decoder[chart.ChartAtom] = deriveDecoder
+  implicit val furnitureDecoder: Decoder[chart.Furniture] = deriveDecoder
+  implicit val tabularDataDecoder: Decoder[chart.TabularData] = deriveDecoder
+  implicit val seriesColourDecoder: Decoder[chart.SeriesColour] = deriveDecoder
+  implicit val axisDecoder: Decoder[chart.Axis] = deriveDecoder
+  implicit val rangeDecoder: Decoder[chart.Range] = deriveDecoder
+  implicit val displaySettingsDecoder: Decoder[chart.DisplaySettings] = deriveDecoder
+  implicit val audioAtomDecoder: Decoder[audio.AudioAtom] = deriveDecoder
+  implicit val offPlatformDecoder: Decoder[audio.OffPlatform] = deriveDecoder
+  implicit val emailSignUpAtomDecoder: Decoder[emailsignup.EmailSignUpAtom] = deriveDecoder
+  implicit val atomDecoder: Decoder[contentatom.Atom] = deriveDecoder
+  implicit val contentChangeDetailsDecoder: Decoder[contentatom.ContentChangeDetails] = deriveDecoder
+  implicit val changeRecordDecoder: Decoder[contentatom.ChangeRecord] = deriveDecoder
+  implicit val contentatomUserDecoder: Decoder[contentatom.User] = deriveDecoder
+  implicit val flagsDecoder: Decoder[contentatom.Flags] = deriveDecoder
+  implicit val atomsDecoder: Decoder[Atoms] = deriveDecoder
+  implicit val pillarDecoder: Decoder[Pillar] = deriveDecoder
+  implicit val contentDecoder: Decoder[Content] = deriveDecoder
+  implicit val aliasPathDecoder: Decoder[AliasPath] = deriveDecoder
+  implicit val schemaOrgDecoder: Decoder[SchemaOrg] = deriveDecoder
+  implicit val schemaRecipeDecoder: Decoder[SchemaRecipe] = deriveDecoder
+  implicit val recipeStepDecoder: Decoder[RecipeStep] = deriveDecoder
+  implicit val authorInfoDecoder: Decoder[AuthorInfo] = deriveDecoder
+  implicit val contentChannelDecoder: Decoder[ContentChannel] = deriveDecoder
+  implicit val channelFieldsDecoder: Decoder[ChannelFields] = deriveDecoder
+  implicit val mostViewedVideoDecoder: Decoder[MostViewedVideo] = deriveDecoder
+  implicit val networkFrontDecoder: Decoder[NetworkFront] = deriveDecoder
+  implicit val packageArticleDecoder: Decoder[PackageArticle] = deriveDecoder
+  implicit val articleDecoder: Decoder[storypackage.Article] = deriveDecoder
+  implicit val packageDecoder: Decoder[Package] = deriveDecoder
+  implicit val itemResponseDecoder: Decoder[ItemResponse] = deriveDecoder
+  implicit val searchResponseDecoder: Decoder[SearchResponse] = deriveDecoder
+  implicit val editionsResponseDecoder: Decoder[EditionsResponse] = deriveDecoder
+  implicit val tagsResponseDecoder: Decoder[TagsResponse] = deriveDecoder
+  implicit val sectionsResponseDecoder: Decoder[SectionsResponse] = deriveDecoder
+  implicit val atomsResponseDecoder: Decoder[AtomsResponse] = deriveDecoder
+  implicit val packagesResponseDecoder: Decoder[PackagesResponse] = deriveDecoder
+  implicit val errorResponseDecoder: Decoder[ErrorResponse] = deriveDecoder
+  implicit val videoStatsResponseDecoder: Decoder[VideoStatsResponse] = deriveDecoder
+  implicit val atomsUsageResponseDecoder: Decoder[AtomUsageResponse] = deriveDecoder
+  implicit val entityDecoder: Decoder[contententity.Entity] = deriveDecoder
+  implicit val placeDecoder: Decoder[place.Place] = deriveDecoder
+  implicit val organisationDecoder: Decoder[organisation.Organisation] = deriveDecoder
+  implicit val entitiesResponseDecoder: Decoder[EntitiesResponse] = deriveDecoder
+  implicit val pillarsResponseDecoder: Decoder[PillarsResponse] = deriveDecoder
+  implicit val embedReachDecoder: Decoder[EmbedReach] = deriveDecoder
 
   // These two need to be written manually. I think the `Map[K, V]` type having 2 type params causes implicit divergence,
   // although shapeless's Lazy is supposed to work around that.

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -95,8 +95,6 @@ object CirceDecoders {
     }
   }
 
-  // The following implicits technically shouldn't be necessary
-  // but stuff doesn't compile without them
   implicit val contentFieldsDecoder: Decoder[ContentFields] = deriveDecoder
   implicit val editionDecoder: Decoder[Edition] = deriveDecoder
   implicit val sponsorshipDecoder: Decoder[Sponsorship] = deriveDecoder
@@ -142,9 +140,9 @@ object CirceDecoders {
   implicit val blockAttributesDecoder: Decoder[BlockAttributes] = deriveDecoder
   implicit val membershipPlaceholderDecoder: Decoder[MembershipPlaceholder] = deriveDecoder
   implicit val userDecoder: Decoder[User] = deriveDecoder
-  implicit val blocksDecoder: Decoder[Blocks] = genBlocksDecoder
+  implicit val blocksDecoder: Decoder[Blocks] = deriveDecoder
   implicit val rightsDecoder: Decoder[Rights] = deriveDecoder
-  implicit val crosswordEntryDecoder: Decoder[CrosswordEntry] = genCrosswordEntryDecoder
+  implicit val crosswordEntryDecoder: Decoder[CrosswordEntry] = deriveDecoder
   implicit val crosswordPositionDecoder: Decoder[CrosswordPosition] = deriveDecoder
   implicit val crosswordDecoder: Decoder[Crossword] = deriveDecoder
   implicit val crosswordDimensionsDecoder: Decoder[CrosswordDimensions] = deriveDecoder
@@ -239,45 +237,4 @@ object CirceDecoders {
   implicit val entitiesResponseDecoder: Decoder[EntitiesResponse] = deriveDecoder
   implicit val pillarsResponseDecoder: Decoder[PillarsResponse] = deriveDecoder
   implicit val embedReachDecoder: Decoder[EmbedReach] = deriveDecoder
-
-  // These two need to be written manually. I think the `Map[K, V]` type having 2 type params causes implicit divergence,
-  // although shapeless's Lazy is supposed to work around that.
-
-  def genBlocksDecoder(implicit blockDecoder: Decoder[Block]): Decoder[Blocks] = Decoder.instance[Blocks] { cursor =>
-    for {
-      main <- cursor.get[Option[Block]]("main")
-      body <- cursor.get[Option[Seq[Block]]]("body")
-      totalBodyBlocks <- cursor.get[Option[Int]]("totalBodyBlocks")
-      requestedBodyBlocks <- cursor.get[Option[Map[String, Seq[Block]]]]("requestedBodyBlocks")
-    } yield Blocks(main, body, totalBodyBlocks, requestedBodyBlocks)
-  }
-
-  def genCrosswordEntryDecoder(implicit dec: Decoder[Option[Map[String,Seq[Int]]]]): Decoder[CrosswordEntry] = Decoder.instance[CrosswordEntry] { cursor =>
-    for {
-      id <- cursor.get[String]("id")
-      number <- cursor.get[Option[Int]]("number")
-      humanNumber <- cursor.get[Option[String]]("humanNumber")
-      direction <- cursor.get[Option[String]]("direction")
-      position <- cursor.get[Option[CrosswordPosition]]("position")
-      separatorLocations <- cursor.get[Option[Map[String, Seq[Int]]]]("separatorLocations")
-      length <- cursor.get[Option[Int]]("length")
-      clue <- cursor.get[Option[String]]("clue")
-      group <- cursor.get[Option[Seq[String]]]("group")
-      solution <- cursor.get[Option[String]]("solution")
-      format <- cursor.get[Option[String]]("format")
-    } yield CrosswordEntry(
-      id,
-      number,
-      humanNumber,
-      direction,
-      position,
-      separatorLocations,
-      length,
-      clue,
-      group,
-      solution,
-      format
-    )
-  }
-
 }

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -34,14 +34,14 @@ object CirceEncoders {
     * We need special encoders for things with Maps, probably because of implicit divergence.
     * TODO - surely there's a way to avoid doing this?!
     */
-  implicit val blockMapEncoder = Encoder.instance[scala.collection.Map[String,Seq[Block]]] { m =>
+  implicit val blockMapEncoder: Encoder[scala.collection.Map[String,Seq[Block]]] = Encoder.instance[scala.collection.Map[String,Seq[Block]]] { m =>
     val fields = m.toList.map {
       case (k, v) => k -> Json.fromValues(v.map(_.asJson))
     }
     Json.fromFields(fields)
   }
 
-  implicit val separatorLocationsEncoder = Encoder.instance[scala.collection.Map[String,Seq[Int]]] { s =>
+  implicit val separatorLocationsEncoder: Encoder[scala.collection.Map[String,Seq[Int]]] = Encoder.instance[scala.collection.Map[String,Seq[Int]]] { s =>
     val fields = s.toList.map {
       case (k, v) => k -> Json.fromValues(v.map(_.asJson))
     }

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -1,11 +1,17 @@
 package com.gu.contentapi.json
 
 import com.gu.contentapi.client.model.v1._
+import com.gu.contentapi.client.model.schemaorg.{SchemaOrg, SchemaRecipe, AuthorInfo, RecipeStep}
+import com.gu.contentatom.thrift.atom._
+import com.gu.contentatom.{thrift => contentatom}
+import com.gu.contententity.thrift.entity._
+import com.gu.contententity.{thrift => contententity}
 import com.twitter.scrooge.ThriftEnum
 import io.circe._
+import io.circe.generic.semiauto._
 import io.circe.syntax._
-import com.gu.fezziwig.CirceScroogeMacros.{encodeThriftStruct, encodeThriftUnion}
-import com.gu.contentatom.thrift.{Atom, AtomData}
+import com.gu.fezziwig.CirceScroogeWhiteboxMacros._
+import com.gu.storypackage.model.{v1 => storypackage}
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -42,23 +48,7 @@ object CirceEncoders {
     Json.fromFields(fields)
   }
 
-  implicit val blockElementEncoder: Encoder[BlockElement] = shapeless.cachedImplicit
-  implicit val networkFrontEncoder = Encoder[NetworkFront]
   implicit val dateTimeEncoder: Encoder[CapiDateTime] = genDateTimeEncoder()
-  implicit val contentFieldsEncoder = Encoder[ContentFields]
-  implicit val editionEncoder = Encoder[Edition]
-  implicit val sponsorshipEncoder = Encoder[Sponsorship]
-  implicit val tagEncoder = Encoder[Tag]
-  implicit val assetEncoder = Encoder[Asset]
-  implicit val elementEncoder = Encoder[Element]
-  implicit val referenceEncoder = Encoder[Reference]
-  implicit val blockEncoder = Encoder[Block]
-  implicit val blocksEncoder = Encoder[Blocks]
-  implicit val rightsEncoder = Encoder[Rights]
-  implicit val crosswordEntryEncoder = Encoder[CrosswordEntry]
-  implicit val crosswordEncoder = Encoder[Crossword]
-  implicit val contentStatsEncoder = Encoder[ContentStats]
-  implicit val sectionEncoder = Encoder[Section]
   implicit val debugEncoder: Encoder[Debug] = Encoder.instance { d =>
     Json.fromJsonObject(
       JsonObject(
@@ -72,27 +62,148 @@ object CirceEncoders {
       }
     )
   }
-  implicit val atomDataEncoder = Encoder[AtomData]
-  implicit val atomEncoder = Encoder[Atom]
-  implicit val atomsEncoder = Encoder[Atoms]
-  implicit val pillarEncoder = Encoder[Pillar]
-  implicit val contentEncoder = Encoder[Content]
-  implicit val mostViewedVideoEncoder = Encoder[MostViewedVideo]
-  implicit val packageEncoder = Encoder[Package]
-  implicit val itemResponseEncoder = Encoder[ItemResponse]
-  implicit val searchResponseEncoder = Encoder[SearchResponse]
-  implicit val editionsResponseEncoder = Encoder[EditionsResponse]
-  implicit val tagsResponseEncoder = Encoder[TagsResponse]
-  implicit val sectionsResponseEncoder = Encoder[SectionsResponse]
-  implicit val atomsResponseEncoder = Encoder[AtomsResponse]
-  implicit val packagesResponseEncoder = Encoder[PackagesResponse]
-  implicit val errorResponseEncoder = Encoder[ErrorResponse]
-  implicit val videoStatsResponseEncoder = Encoder[VideoStatsResponse]
-  implicit val atomsUsageResponseEncoder = Encoder[AtomUsageResponse]
-  implicit val entitiesResponseEncoder = Encoder[EntitiesResponse]
-  implicit val pillarsResponseEncoder = Encoder[PillarsResponse]
-  implicit val embedTrackingEncoder = Encoder[EmbedTracking]
-  implicit val embedReachEncoder = Encoder[EmbedReach]
+
+  implicit val contentFieldsEncoder: Encoder[ContentFields] = deriveEncoder
+  implicit val editionEncoder: Encoder[Edition] = deriveEncoder
+  implicit val sponsorshipEncoder: Encoder[Sponsorship] = deriveEncoder
+  implicit val sponsorshipTargetingEncoder: Encoder[SponsorshipTargeting] = deriveEncoder
+  implicit val sponsorshipLogoDimensionsEncoder: Encoder[SponsorshipLogoDimensions] = deriveEncoder
+  implicit val tagEncoder: Encoder[Tag] = deriveEncoder
+  implicit val podcastEncoder: Encoder[Podcast] = deriveEncoder
+  implicit val podcastCategoryEncoder: Encoder[PodcastCategory] = deriveEncoder
+  implicit val assetEncoder: Encoder[Asset] = deriveEncoder
+  implicit val assetFieldsEncoder: Encoder[AssetFields] = deriveEncoder
+  implicit val cartoonVariantEncoder: Encoder[CartoonVariant] = deriveEncoder
+  implicit val cartoonImageEncoder: Encoder[CartoonImage] = deriveEncoder
+  implicit val elementEncoder: Encoder[Element] = deriveEncoder
+  implicit val referenceEncoder: Encoder[Reference] = deriveEncoder
+  implicit val blockElementEncoder: Encoder[BlockElement] = deriveEncoder
+  implicit val textElementFieldsEncoder: Encoder[TextElementFields] = deriveEncoder
+  implicit val videoElementFieldsEncoder: Encoder[VideoElementFields] = deriveEncoder
+  implicit val tweetElementFieldsEncoder: Encoder[TweetElementFields] = deriveEncoder
+  implicit val imageElementFieldsEncoder: Encoder[ImageElementFields] = deriveEncoder
+  implicit val audioElementFieldsEncoder: Encoder[AudioElementFields] = deriveEncoder
+  implicit val pullquoteElementFieldsEncoder: Encoder[PullquoteElementFields] = deriveEncoder
+  implicit val interactiveElementFieldsEncoder: Encoder[InteractiveElementFields] = deriveEncoder
+  implicit val standardElementFieldsEncoder: Encoder[StandardElementFields] = deriveEncoder
+  implicit val witnessElementFieldsEncoder: Encoder[WitnessElementFields] = deriveEncoder
+  implicit val richLinkElementFieldsEncoder: Encoder[RichLinkElementFields] = deriveEncoder
+  implicit val membershipElementFieldsEncoder: Encoder[MembershipElementFields] = deriveEncoder
+  implicit val embedElementFieldsEncoder: Encoder[EmbedElementFields] = deriveEncoder
+  implicit val instagramElementFieldsEncoder: Encoder[InstagramElementFields] = deriveEncoder
+  implicit val commentElementFieldsEncoder: Encoder[CommentElementFields] = deriveEncoder
+  implicit val vineElementFieldsEncoder: Encoder[VineElementFields] = deriveEncoder
+  implicit val contentAtomElementFieldsEncoder: Encoder[ContentAtomElementFields] = deriveEncoder
+  implicit val embedTrackingEncoder: Encoder[EmbedTracking] = deriveEncoder
+  implicit val codeElementFieldsEncoder: Encoder[CodeElementFields] = deriveEncoder
+  implicit val calloutElementFieldsEncoder: Encoder[CalloutElementFields] = deriveEncoder
+  implicit val cartoonElementFieldsEncoder: Encoder[CartoonElementFields] = deriveEncoder
+  implicit val recipeElementFieldsEncoder: Encoder[RecipeElementFields] = deriveEncoder
+  implicit val listElementFieldsEncoder: Encoder[ListElementFields] = deriveEncoder
+  implicit val listItemEncoder: Encoder[ListItem] = deriveEncoder
+  implicit val timelineElementFieldsEncoder: Encoder[TimelineElementFields] = deriveEncoder
+  implicit val timelineSectionEncoder: Encoder[TimelineSection] = deriveEncoder
+  implicit val timelineEventEncoder: Encoder[TimelineEvent] = deriveEncoder
+  implicit val blockEncoder: Encoder[Block] = deriveEncoder
+  implicit val blockAttributesEncoder: Encoder[BlockAttributes] = deriveEncoder
+  implicit val membershipPlaceholderEncoder: Encoder[MembershipPlaceholder] = deriveEncoder
+  implicit val userEncoder: Encoder[User] = deriveEncoder
+  implicit val blocksEncoder: Encoder[Blocks] = deriveEncoder // changed
+  implicit val rightsEncoder: Encoder[Rights] = deriveEncoder
+  implicit val crosswordEntryEncoder: Encoder[CrosswordEntry] = deriveEncoder // changed
+  implicit val crosswordPositionEncoder: Encoder[CrosswordPosition] = deriveEncoder
+  implicit val crosswordEncoder: Encoder[Crossword] = deriveEncoder
+  implicit val crosswordDimensionsEncoder: Encoder[CrosswordDimensions] = deriveEncoder
+  implicit val crosswordCreatorEncoder: Encoder[CrosswordCreator] = deriveEncoder
+  implicit val contentStatsEncoder: Encoder[ContentStats] = deriveEncoder
+  implicit val sectionEncoder: Encoder[Section] = deriveEncoder
+  implicit val atomDataEncoder: Encoder[contentatom.AtomData] = deriveEncoder
+  implicit val quizAtomEncoder: Encoder[quiz.QuizAtom] = deriveEncoder
+  implicit val quizContentEncoder: Encoder[quiz.QuizContent] = deriveEncoder
+  implicit val questionEncoder: Encoder[quiz.Question] = deriveEncoder
+  implicit val answerEncoder: Encoder[quiz.Answer] = deriveEncoder
+  implicit val quizAssetEncoder: Encoder[quiz.Asset] = deriveEncoder
+  implicit val resultGroupsEncoder: Encoder[quiz.ResultGroups] = deriveEncoder
+  implicit val resultGroupEncoder: Encoder[quiz.ResultGroup] = deriveEncoder
+  implicit val resultBucketsEncoder: Encoder[quiz.ResultBuckets] = deriveEncoder
+  implicit val resultBucketEncoder: Encoder[quiz.ResultBucket] = deriveEncoder
+  implicit val mediaAtomEncoder: Encoder[media.MediaAtom] = deriveEncoder
+  implicit val imageEncoder: Encoder[contentatom.Image] = deriveEncoder
+  implicit val imageAssetEncoder: Encoder[contentatom.ImageAsset] = deriveEncoder
+  implicit val imageAssetDimensionsEncoder: Encoder[contentatom.ImageAssetDimensions] = deriveEncoder
+  implicit val mediaAssetEncoder: Encoder[media.Asset] = deriveEncoder
+  implicit val mediaMetadataEncoder: Encoder[media.Metadata] = deriveEncoder
+  implicit val mediaPlutoDataEncoder: Encoder[media.PlutoData] = deriveEncoder
+  implicit val mediaYoutubeDataEncoder: Encoder[media.YoutubeData] = deriveEncoder
+  implicit val explainerAtomEncoder: Encoder[explainer.ExplainerAtom] = deriveEncoder
+  implicit val ctaAtomEncoder: Encoder[cta.CTAAtom] = deriveEncoder
+  implicit val interactiveAtomEncoder: Encoder[interactive.InteractiveAtom] = deriveEncoder
+  implicit val reviewAtomEncoder: Encoder[review.ReviewAtom] = deriveEncoder
+  implicit val ratingEncoder: Encoder[review.Rating] = deriveEncoder
+  implicit val restaurantEncoder: Encoder[restaurant.Restaurant] = deriveEncoder
+  implicit val addressEncoder: Encoder[contententity.Address] = deriveEncoder
+  implicit val geolocationEncoder: Encoder[contententity.Geolocation] = deriveEncoder
+  implicit val gameEncoder: Encoder[game.Game] = deriveEncoder
+  implicit val priceEncoder: Encoder[contententity.Price] = deriveEncoder
+  implicit val filmEncoder: Encoder[film.Film] = deriveEncoder
+  implicit val personEncoder: Encoder[person.Person] = deriveEncoder
+  implicit val qAndAAtomEncoder: Encoder[qanda.QAndAAtom] = deriveEncoder
+  implicit val qAndAItemEncoder: Encoder[qanda.QAndAItem] = deriveEncoder
+  implicit val guideAtomEncoder: Encoder[guide.GuideAtom] = deriveEncoder
+  implicit val guideItemEncoder: Encoder[guide.GuideItem] = deriveEncoder
+  implicit val profileAtomEncoder: Encoder[profile.ProfileAtom] = deriveEncoder
+  implicit val profileItemEncoder: Encoder[profile.ProfileItem] = deriveEncoder
+  implicit val timelineAtomEncoder: Encoder[timeline.TimelineAtom] = deriveEncoder
+  implicit val timelineItemEncoder: Encoder[timeline.TimelineItem] = deriveEncoder
+  implicit val commonsDivisionEncoder: Encoder[commonsdivision.CommonsDivision] = deriveEncoder
+  implicit val votesEncoder: Encoder[commonsdivision.Votes] = deriveEncoder
+  implicit val mpEncoder: Encoder[commonsdivision.Mp] = deriveEncoder
+  implicit val chartAtomEncoder: Encoder[chart.ChartAtom] = deriveEncoder
+  implicit val furnitureEncoder: Encoder[chart.Furniture] = deriveEncoder
+  implicit val tabularDataEncoder: Encoder[chart.TabularData] = deriveEncoder
+  implicit val seriesColourEncoder: Encoder[chart.SeriesColour] = deriveEncoder
+  implicit val axisEncoder: Encoder[chart.Axis] = deriveEncoder
+  implicit val rangeEncoder: Encoder[chart.Range] = deriveEncoder
+  implicit val displaySettingsEncoder: Encoder[chart.DisplaySettings] = deriveEncoder
+  implicit val audioAtomEncoder: Encoder[audio.AudioAtom] = deriveEncoder
+  implicit val offPlatformEncoder: Encoder[audio.OffPlatform] = deriveEncoder
+  implicit val emailSignUpAtomEncoder: Encoder[emailsignup.EmailSignUpAtom] = deriveEncoder
+  implicit val atomEncoder: Encoder[contentatom.Atom] = deriveEncoder
+  implicit val contentChangeDetailsEncoder: Encoder[contentatom.ContentChangeDetails] = deriveEncoder
+  implicit val changeRecordEncoder: Encoder[contentatom.ChangeRecord] = deriveEncoder
+  implicit val contentatomUserEncoder: Encoder[contentatom.User] = deriveEncoder
+  implicit val flagsEncoder: Encoder[contentatom.Flags] = deriveEncoder
+  implicit val atomsEncoder: Encoder[Atoms] = deriveEncoder
+  implicit val pillarEncoder: Encoder[Pillar] = deriveEncoder
+  implicit val contentEncoder: Encoder[Content] = deriveEncoder
+  implicit val aliasPathEncoder: Encoder[AliasPath] = deriveEncoder
+  implicit val schemaOrgEncoder: Encoder[SchemaOrg] = deriveEncoder
+  implicit val schemaRecipeEncoder: Encoder[SchemaRecipe] = deriveEncoder
+  implicit val recipeStepEncoder: Encoder[RecipeStep] = deriveEncoder
+  implicit val authorInfoEncoder: Encoder[AuthorInfo] = deriveEncoder
+  implicit val contentChannelEncoder: Encoder[ContentChannel] = deriveEncoder
+  implicit val channelFieldsEncoder: Encoder[ChannelFields] = deriveEncoder
+  implicit val mostViewedVideoEncoder: Encoder[MostViewedVideo] = deriveEncoder
+  implicit val networkFrontEncoder: Encoder[NetworkFront] = deriveEncoder
+  implicit val packageArticleEncoder: Encoder[PackageArticle] = deriveEncoder
+  implicit val articleEncoder: Encoder[storypackage.Article] = deriveEncoder
+  implicit val packageEncoder: Encoder[Package] = deriveEncoder
+  implicit val itemResponseEncoder: Encoder[ItemResponse] = deriveEncoder
+  implicit val searchResponseEncoder: Encoder[SearchResponse] = deriveEncoder
+  implicit val editionsResponseEncoder: Encoder[EditionsResponse] = deriveEncoder
+  implicit val tagsResponseEncoder: Encoder[TagsResponse] = deriveEncoder
+  implicit val sectionsResponseEncoder: Encoder[SectionsResponse] = deriveEncoder
+  implicit val atomsResponseEncoder: Encoder[AtomsResponse] = deriveEncoder
+  implicit val packagesResponseEncoder: Encoder[PackagesResponse] = deriveEncoder
+  implicit val errorResponseEncoder: Encoder[ErrorResponse] = deriveEncoder
+  implicit val videoStatsResponseEncoder: Encoder[VideoStatsResponse] = deriveEncoder
+  implicit val atomsUsageResponseEncoder: Encoder[AtomUsageResponse] = deriveEncoder
+  implicit val entityEncoder: Encoder[contententity.Entity] = deriveEncoder
+  implicit val placeEncoder: Encoder[place.Place] = deriveEncoder
+  implicit val organisationEncoder: Encoder[organisation.Organisation] = deriveEncoder
+  implicit val entitiesResponseEncoder: Encoder[EntitiesResponse] = deriveEncoder
+  implicit val pillarsResponseEncoder: Encoder[PillarsResponse] = deriveEncoder
+  implicit val embedReachEncoder: Encoder[EmbedReach] = deriveEncoder
 
   def genDateTimeEncoder(truncate: Boolean = true): Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>
     val dateTime: OffsetDateTime = OffsetDateTime.parse(capiDateTime.iso8601)

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -30,24 +30,6 @@ object CirceEncoders {
 
   implicit def officeEncoder[A <: Office]: Encoder[A] = Encoder[String].contramap(o => o.name.toUpperCase)
 
-  /**
-    * We need special encoders for things with Maps, probably because of implicit divergence.
-    * TODO - surely there's a way to avoid doing this?!
-    */
-  implicit val blockMapEncoder: Encoder[scala.collection.Map[String,Seq[Block]]] = Encoder.instance[scala.collection.Map[String,Seq[Block]]] { m =>
-    val fields = m.toList.map {
-      case (k, v) => k -> Json.fromValues(v.map(_.asJson))
-    }
-    Json.fromFields(fields)
-  }
-
-  implicit val separatorLocationsEncoder: Encoder[scala.collection.Map[String,Seq[Int]]] = Encoder.instance[scala.collection.Map[String,Seq[Int]]] { s =>
-    val fields = s.toList.map {
-      case (k, v) => k -> Json.fromValues(v.map(_.asJson))
-    }
-    Json.fromFields(fields)
-  }
-
   implicit val dateTimeEncoder: Encoder[CapiDateTime] = genDateTimeEncoder()
   implicit val debugEncoder: Encoder[Debug] = Encoder.instance { d =>
     Json.fromJsonObject(


### PR DESCRIPTION
# What does this change?

This PR updates the version of fezziwig to 2.0.0, which includes the changes from [fezziwig PR#48](https://github.com/guardian/fezziwig/pull/48), and updates the CirceEncoders and CirceDecoders as required.

Unfortunately this requires a lot of boilerplate semiauto derivation! But fortunately, it’s a little less mysterious: we no longer need fully manual encoders for Map-containing types, for example. Compile times are also somewhat improved, as described in that PR.