### PR TITLE
Add quick-cryptic crossword type

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -193,7 +193,9 @@ enum CrosswordType {
 
     DIAN_QUIPTIC_CROSSWORD = 6,
 
-    WEEKEND = 7
+    WEEKEND = 7,
+
+    QUICK_CRYPTIC = 8
 }
 
 enum Office {


### PR DESCRIPTION
Adds the upcoming Quick-Cryptic crossword type to the CAPI models. Required to have the crossword type correctly parsed from ES and returned in the Concierge response.

Tested as a local snapshot and confirmed working end-to-end through local Crosswordv2/Composer/CAPI

Before:

```
...
"crossword": {
  "type": "enum-unknown-crossword-type-1",
...
```

After:

```
...
"crossword": {
  "type": "quick-cryptic",
...
```