### PR TITLE
Ensure sbt detects version incompatibilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,7 @@ lazy val scala = Project(id = "content-api-models-scala", base = file("scala"))
   * JSON parser project
   */
 lazy val json = Project(id = "content-api-models-json", base = file("json"))
-  .dependsOn(scala % "provided")
+  .dependsOn(scala)
   .settings(artifactProductionSettings)
   .settings(
     description := "Json parser for the Guardian's Content API models",


### PR DESCRIPTION
This PR https://github.com/guardian/content-api-models/pull/38#discussion_r69474445 set the json's dependency required as "provided" but we are not entirely clearly sure why thta was needed.

ref: https://www.baeldung.com/maven-dependency-scopes#bd-2-provided

It caused problem now because we are not able to see sbt checking on incompatible version, thanks to work done in gha-scala-release where we expect incompatible version fatal errors - https://github.com/guardian/gha-scala-library-release-workflow/blob/add-configuration-guidence/docs/configuration.md#recommended-sbt-plugins

co-authored with @rtyley along with @emdash-ie 

## How to test

Try change version for capi-model-scala-client to older version so that while running test/compile sbt should point out the issues in incomptaible versions.

## How can we measure success?

warnings/errors should be on sbt terminal

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

