### PR TITLE
Tweak a couple of recipe fields to be arrays of strings instead of strings

### DIFF
--- a/models/src/main/thrift/content/schema_org.thrift
+++ b/models/src/main/thrift/content/schema_org.thrift
@@ -22,8 +22,8 @@ struct SchemaRecipe {
     14: optional string cookTime
     15: optional string totalTime
     16: optional AuthorInfo author
-    17: optional string suitableForDiet
-    18: optional string cookingMethod
+    17: optional list<string> suitableForDiet
+    18: optional list<string> cookingMethod
 }
 
 struct RecipeStep {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fixing a silly mistake with the thrift. Although it's usually a no-no to change the shape of thrift fields in this case we should be in the clear given it's not being used anywhere yet

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
