### PR TITLE
Bump version of content-entity and content-atom preview

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import sbtrelease.ReleaseStateTransformations.*
 import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
-val contentEntityVersion = "2.2.1"
-val contentAtomVersion = "4.0.0"
+val contentEntityVersion = "3.0.3"
+val contentAtomVersion = "4.0.2-PREVIEW.db-rttest-content-entity-release.2024-03-26T1749.cb6c4e64"//TODO - need to update this with latest release that has new content-entity version already
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "3.0.3"
-val contentAtomVersion = "4.0.2-PREVIEW.db-rttest-content-entity-release.2024-03-26T1749.cb6c4e64"//TODO - need to update this with latest release that has new content-entity version already
+val contentAtomVersion = "4.0.4"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes


### PR DESCRIPTION

## What does this change?

We are testing latest `content-entity` release after implementing gha-scala-release-process in it.
Since we bumped its version to content-atom and released its preview release hence umping that too to avoid semver version conflicts.
https://github.com/guardian/content-atom/pull/169

## How to test

Make preview release for this and will test in `content-api-scala-client`

