### PR TITLE
Model multi-byline contributor as strings instead of Tags

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -898,7 +898,8 @@ struct ListItem {
 
     2: optional string title;
 
-    3: optional list<string> contributorIds;
+    // NOT USED. contributors has been superceded by contributorIds
+    // 3: optional list<Tag> contributors;
 
     4: optional string bio;
 
@@ -909,6 +910,8 @@ struct ListItem {
     7: optional string byline;
 
     8: optional string bylineHtml;
+
+    9: optional list<string> contributorIds;
 
 }
 

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -898,7 +898,7 @@ struct ListItem {
 
     2: optional string title;
 
-    3: optional list<Tag> contributors;
+    3: optional list<string> contributorIds;
 
     4: optional string bio;
 


### PR DESCRIPTION
## What does this change?

Previously, we assumed multi-byline contributors would be modelled as tag objects in CAPI (https://github.com/guardian/content-api-models/pull/247).

However, for rendering purposes, it's actually sufficient to model them as IDs (e.g. `["profile/owen-jones"]`). When we render the multi-byline element, these IDs will be mapped to the contributor tags on the article level, which contain all the relevant metadata (image URL, etc.)

Example CAPI response (simplified):

```
{
  "blocks": {
    "body": [
      {
        "elements": [
          {
            "type": "list",
            "listTypeData": {
              "type": "multi-byline"
              "items": [
                {
                  "title": "Labour is the only party serious about building homes",
                  "bio": "David Miliband is CEO of the International Rescue Committee",
                  "elements": [ ... ],
                  "contributorIds": ["profile/davidmiliband"],
                  "bylineHtml": "<a href=\"profile/davidmiliband\">David Miliband</a>"
                }
              ]
            }
          }
        ]
      }
    ]
  }
  "tags": [
    {
        "id": "profile/davidmiliband",
        "type": "contributor",
        "bylineImageUrl": "https://uploads.guim.co.uk/2023/09/15/David_Miliband.jpg",
        // etc.
    },
  ]
}
```

To this end, Porter already writes contributors to elasticsearch as IDs (https://github.com/guardian/content-api/pull/2879).

This mismatch between Porter and Concierge only came to light recently when testing a branch of flexible-content which began sending contributors data to the Kinesis stream (https://github.com/guardian/flexible-content/pull/4966). Defining the type of contributors as tags imposed a requirement on Concierge to transform those IDs into tag objects, which caused Concierge to explode.

Emily provided a more complete explanation of the problem here: https://github.com/guardian/content-api-models/pull/247#issuecomment-2434895717

The fix is to model contributors as IDs instead of tags. 

I have renamed this field `contributorIds` to make this distinction clearer.

## Next steps...

1) Update **Concierge** to use this model https://github.com/guardian/content-api/pull/2928
2) Update **Porter** to:
- use string IDs instead of numeric ones, 
- rename `contributors` to `contributorIds`
- automatically lift multi-byline contributor tags to the article level
https://github.com/guardian/content-api/pull/2929
3) Update **Composer** to send contributor data to the Kinesis stream https://github.com/guardian/flexible-content/pull/4966