### PR TITLE
Update clashing dependencies for shared model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import sbtrelease.ReleaseStateTransformations.*
 import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
-val contentEntityVersion = "3.0.3"
-val contentAtomVersion = "4.0.4"
+val contentEntityVersion = "4.0.0"
+val contentAtomVersion = "6.0.0"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes


### PR DESCRIPTION
In https://github.com/guardian/content-api/pull/2953 I’m trying to work out a model shared between porter and concierge for the data that’s written to elasticsearch. Making concierge depend on the shared model has lead to some dependency clashes: this commit updates some dependencies here (specifically content-entity and content-atom) to resolve those clashes.

TODO: full description, etc.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
