### PR TITLE
Add field for deeply-read

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -2016,6 +2016,8 @@ struct ItemResponse {
 
     18: optional list<Content> mostViewed
 
+    // deeplyRead is #38
+
     19: optional list<Content> leadContent
 
     /* New story packages */
@@ -2055,6 +2057,8 @@ struct ItemResponse {
     36: optional contentatom.Atom audio
 
     37: optional contentatom.Atom emailsignup
+
+    38: optional list<Content> deeplyRead
 }
 
 struct TagsResponse {


### PR DESCRIPTION
## What does this change?

Adds new field for deeply read articles. See https://github.com/guardian/content-api/pull/2971