### PR TITLE
add sunday-quick crossword type

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -200,7 +200,9 @@ enum CrosswordType {
 
     QUICK_CRYPTIC = 8,
 
-    SPECIAL = 9
+    SPECIAL = 9,
+
+    SUNDAY_QUICK = 10
 }
 
 enum Office {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the upcoming Sunday quick crossword type (distinct from Quick!) to the CAPI models. Required to have the crossword type correctly parsed from ES and returned in the Concierge response.
