### PR TITLE
Added link to the API model

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -237,5 +237,5 @@ object CirceDecoders {
   implicit val entitiesResponseDecoder: Decoder[EntitiesResponse] = deriveDecoder
   implicit val pillarsResponseDecoder: Decoder[PillarsResponse] = deriveDecoder
   implicit val embedReachDecoder: Decoder[EmbedReach] = deriveDecoder
-  implicit val styledLinkElementFieldsDecoder: Decoder[StyledLinkElementFields] = deriveDecoder
+  implicit val linkElementFieldsDecoder: Decoder[LinkElementFields] = deriveDecoder
 }

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -237,4 +237,5 @@ object CirceDecoders {
   implicit val entitiesResponseDecoder: Decoder[EntitiesResponse] = deriveDecoder
   implicit val pillarsResponseDecoder: Decoder[PillarsResponse] = deriveDecoder
   implicit val embedReachDecoder: Decoder[EmbedReach] = deriveDecoder
+  implicit val styledLinkElementFieldsDecoder: Decoder[StyledLinkElementFields] = deriveDecoder
 }

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -186,7 +186,7 @@ object CirceEncoders {
   implicit val entitiesResponseEncoder: Encoder[EntitiesResponse] = deriveEncoder
   implicit val pillarsResponseEncoder: Encoder[PillarsResponse] = deriveEncoder
   implicit val embedReachEncoder: Encoder[EmbedReach] = deriveEncoder
-  implicit val styledLinkElementFieldsEncoder: Encoder[StyledLinkElementFields] = deriveEncoder
+  implicit val linkElementFieldsEncoder: Encoder[LinkElementFields] = deriveEncoder
 
   def genDateTimeEncoder(truncate: Boolean = true): Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>
     val dateTime: OffsetDateTime = OffsetDateTime.parse(capiDateTime.iso8601)

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -186,7 +186,7 @@ object CirceEncoders {
   implicit val entitiesResponseEncoder: Encoder[EntitiesResponse] = deriveEncoder
   implicit val pillarsResponseEncoder: Encoder[PillarsResponse] = deriveEncoder
   implicit val embedReachEncoder: Encoder[EmbedReach] = deriveEncoder
-  implicit val styledLinkElementFieldsEncoder: Encoder[styledLinkElementFields] = deriveEncoder
+  implicit val styledLinkElementFieldsEncoder: Encoder[StyledLinkElementFields] = deriveEncoder
 
   def genDateTimeEncoder(truncate: Boolean = true): Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>
     val dateTime: OffsetDateTime = OffsetDateTime.parse(capiDateTime.iso8601)

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -186,6 +186,7 @@ object CirceEncoders {
   implicit val entitiesResponseEncoder: Encoder[EntitiesResponse] = deriveEncoder
   implicit val pillarsResponseEncoder: Encoder[PillarsResponse] = deriveEncoder
   implicit val embedReachEncoder: Encoder[EmbedReach] = deriveEncoder
+  implicit val styledLinkElementFieldsEncoder: Encoder[styledLinkElementFields] = deriveEncoder
 
   def genDateTimeEncoder(truncate: Boolean = true): Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>
     val dateTime: OffsetDateTime = OffsetDateTime.parse(capiDateTime.iso8601)

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -440,13 +440,17 @@ struct PullquoteElementFields {
     7: optional string sourceDomain
 }
 
+enum LinkType {
+    PRODUCT_BUTTON = 0,
+}
+
 struct LinkElementFields {
 
     1: optional string label;
 
     2: optional string url;
 
-    3: optional string linkType;
+    3: optional LinkType linkType;
 }
 
 struct TweetElementFields {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -151,10 +151,7 @@ enum ElementType {
 
     TIMELINE = 24
 
-    /*
-     * A styled link element
-     */
-    STYLED_LINK = 25
+    LINK = 25
 }
 
 enum TagType {
@@ -443,13 +440,13 @@ struct PullquoteElementFields {
     7: optional string sourceDomain
 }
 
-struct StyledLinkElementFields {
+struct LinkElementFields {
 
     1: optional string label;
 
     2: optional string url;
 
-    3: optional string styledLinkType;
+    3: optional string linkType;
 }
 
 struct TweetElementFields {
@@ -1021,7 +1018,7 @@ struct BlockElement {
 
     27: optional TimelineElementFields timelineTypeData
 
-    28: optional StyledLinkElementFields styledLinkTypeData
+    28: optional LinkElementFields linkTypeData
 }
 
 struct MembershipPlaceholder {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -150,6 +150,11 @@ enum ElementType {
     LIST = 23
 
     TIMELINE = 24
+
+    /*
+     * A styled link element
+     */
+    STYLED_LINK = 25
 }
 
 enum TagType {
@@ -436,6 +441,15 @@ struct PullquoteElementFields {
 //    6: optional i32 width
 
     7: optional string sourceDomain
+}
+
+struct StyledLinkElementFields {
+
+    1: optional string label;
+
+    2: optional string url;
+
+    3: optional string styledLinkType;
 }
 
 struct TweetElementFields {
@@ -1006,6 +1020,8 @@ struct BlockElement {
     26: optional ListElementFields listTypeData
 
     27: optional TimelineElementFields timelineTypeData
+
+    28: optional StyledLinkElementFields styledLinkTypeData
 }
 
 struct MembershipPlaceholder {


### PR DESCRIPTION
Co-authored-by: Emma Imber <emma-jo.imber@guardian.co.uk>

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Added link to the API model

The reason behind this change can be found [here](https://docs.google.com/document/d/1mG5z_RifG73DAzNGo7Jeq3IADDlLLM5YeywvbwsTD6I/edit?tab=t.0#heading=h.8rus61czp6e9) 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
