### PR TITLE
Add episodic artwork fields to CAPI model

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1375,6 +1375,10 @@ struct Podcast {
     11: optional string acastId
 
     12: optional string pocketCastsUrl
+
+    13: optional bool episodicArtworkEnabled
+
+    14: optional CapiDateTime episodicArtworkEnabledFrom
 }
 
 struct Tag {


### PR DESCRIPTION
## What does this change?

We are in the process of adding two new podcast metadata fields to the tag model: 

- `episodicArtworkEnabled` (boolean)
- `episodicArtworkEnabledFrom` (datetime)

They are already supported in Porter: https://github.com/guardian/content-api/pull/3093

Now we need to add them to the CAPI model

## How to test

This will be testable when we have a Concierge PR up which consumes this version of the library

## Related PRs

- [tags-thrift-schema](https://github.com/guardian/tags-thrift-schema/pull/48)
- [tagmanager](https://github.com/guardian/tagmanager/pull/558)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3093)
- [content-api-models](https://github.com/guardian/content-api-models/pull/261)  <- you are here
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3100) 
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/443)
- [itunes-rss](https://github.com/guardian/itunes-rss/pull/180)
