### PR TITLE
Add new podcast fields to model

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -476,6 +476,12 @@ struct TweetElementFields {
     10: optional bool isMandatory
 }
 
+enum PodcastEpisodeType {
+    FULL = 0,
+    TRAILER = 1,
+    BONUS = 2
+}
+
 struct AudioElementFields {
 
     1: optional string html
@@ -507,6 +513,12 @@ struct AudioElementFields {
     14: optional string sourceDomain
 
     15: optional bool isMandatory
+
+    16: optional i32 podcastEpisodeNumber
+
+    17: optional i32 podcastSeasonNumber
+
+    18: optional PodcastEpisodeType podcastEpisodeType
 }
 
 struct VideoElementFields {


### PR DESCRIPTION
## What does this change?

We are in the process of adding three new podcast fields to CAPI. These are:

- `podcastEpisodeNumber` (optional) - the episode number of the podcast
- `podcastSeasonNumber` (optional) - the season number of the podcast
- `podcastEpisodeType` (optional) - the episode type of the podcast. Can be one of full, trailer or bonus. If absent, we assume it's a full episode

More info in the flexible-model change: https://github.com/guardian/flexible-model/pull/82

This PR adds the new fields to the CAPI model.

Associated Porter change: https://github.com/guardian/content-api/pull/3149

## How to test

Tested here: https://github.com/guardian/content-api/pull/3150

## Related PRs

- [flexible-model](https://github.com/guardian/flexible-model/pull/82)
- [flexible-content](https://github.com/guardian/flexible-content/pull/5768)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3149)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3180)
- [content-api-models](https://github.com/guardian/content-api-models/pull/262) <- you are here 
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3150)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/445)
- [itunes-rss](https://github.com/guardian/itunes-rss/pull/183)
