### PR TITLE
Update content atom model to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "3.0.3"
-val contentAtomVersion = "4.0.4"
+val contentAtomVersion = "6.1.0"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes


### PR DESCRIPTION
## What does this change?

Bumps to include https://github.com/guardian/content-atom/releases/tag/v6.1.0.