### PR TITLE
Bump contentAtomVersion for new fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "4.0.0"
-val contentAtomVersion = "9.0.0"
+val contentAtomVersion = "10.0.0"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes


### PR DESCRIPTION
## What does this change?
Bump content-atom-model-thrift to version "10.0.0" to support new media fields, `duration` and `hasAudio` and the new audio field `field trackUrlWithAds`.
 
The new fields are added here: 
- https://github.com/guardian/content-atom/pull/208 
- https://github.com/guardian/content-atom/pull/210

## How has this change been tested?
This will be tested on the Concierge branch: https://github.com/guardian/content-api/pull/ 

## Relevant PRs

- [content-atom](https://github.com/guardian/content-atom/pull/208)
- [atom-maker](https://github.com/guardian/atom-maker/pull/141)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3335)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3336)
- [content-api-models](https://github.com/guardian/content-api-models/pull/297)  <- you are here
- [content-api (Concierge)](https://github.com/guardian/content-api/pull/3337)
