### PR TITLE
Add new field with podcasts url including ads

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -299,7 +299,7 @@ struct AssetFields {
 
   12: optional string name
 
-  13: optional string secureFile
+  13: optional string secureFile // see also 71: secureFileWithAds
 
   14: optional bool isMaster
 
@@ -415,6 +415,8 @@ struct AssetFields {
   69: optional bool isMandatory
 
   70: optional list<CartoonVariant> cartoonVariants
+
+  71: optional string secureFileWithAds
 }
 
 struct Asset {


### PR DESCRIPTION
## What does this change?

Currently platforms generate the ad url based on the secureFile, but we are about to make the logic around this generation a bit more complicated so would prefer for it to be done in one place. For now that will be concierge, and in future it may be upstream of porter.
