### PR TITLE
Upgrade to latest scrooge-typescript to fix build

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.0")
 
 addDependencyTreePlugin


### PR DESCRIPTION
Version 1.6.0 of sbt-scrooge-typescript has a bug that results in the build using the system installed version `tsc` rather than the one specified in the plugin.

As a result we are now using tsc v6.0.2 while the plugin expects v4.1.5. The newer version of typescript has deprecated targeting es5 which results in a build failure.

https://github.com/guardian/scrooge-extras/pull/25 fixed this bug. This PR upgrades us to v4.0.0 of the plugin, which includes this fix and will mean that we use the version of tsc that the plugin intends (now tsc v5.9.3).


## Before

<img width="1076" height="160" alt="Screenshot 2026-04-21 at 11 37 12" src="https://github.com/user-attachments/assets/4eb3d45a-9985-4691-b589-e22c3563bac5" />
Red tick next to NPM Release

## After
<img width="1076" height="160" alt="Screenshot 2026-04-21 at 11 36 58" src="https://github.com/user-attachments/assets/a48b5e1b-929d-444f-98d3-2fb9b91f8c5a" />
Green tick next to NPM Release

