### PR TITLE
Bump content atom thrift model to v11 to add tags on content atoms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "4.0.0"
-val contentAtomVersion = "10.0.0"
+val contentAtomVersion = "11.0.0"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes

--- a/json/src/test/resources/templates/item-content-with-atom-explainer.json
+++ b/json/src/test/resources/templates/item-content-with-atom-explainer.json
@@ -23,6 +23,7 @@
           "atomType" : "explainer",
           "labels" : [ ],
           "commissioningDesks" : [ ],
+          "tagIds" : [ ],
           "defaultHtml" : "<div</div>\n",
           "data" : {
             "explainer": {

--- a/json/src/test/resources/templates/item-content-with-atom-media.json
+++ b/json/src/test/resources/templates/item-content-with-atom-media.json
@@ -22,6 +22,7 @@
           "atomType" : "media",
           "labels" : [ ],
           "commissioningDesks" : [ ],
+          "tagIds" : [ ],
           "defaultHtml" : "<div</div>\n",
           "data" : {
             "media": {

--- a/json/src/test/resources/templates/item-content-with-atom-quiz.json
+++ b/json/src/test/resources/templates/item-content-with-atom-quiz.json
@@ -22,6 +22,7 @@
             "atomType" : "quiz",
             "labels" : [ ],
             "commissioningDesks" : [ ],
+            "tagIds" : [ ],
             "defaultHtml" : "<div class=\"quiz\"><h1 class=\"quiz__title\">Test quiz in code</h1><ol class=\"quiz__questions\"><li class=\"quiz__question question\"><p class=\"question__text\">Will this quiz publish in code?</p><ol class=\"question__answers\" type=\"A\"><li class=\"question__answer answer\"><img src=\"\" alt=\"\" /><p class=\"answer__text\">Yes</p></li><li class=\"question__answer answer\"><img src=\"\" alt=\"\" /><p class=\"answer__text\">No</p></li><li class=\"question__answer answer\"><img src=\"\" alt=\"\" /><p class=\"answer__text\"></p></li><li class=\"question__answer answer\"><img src=\"\" alt=\"\" /><p class=\"answer__text\"></p></li></ol></li></ol><h2 class=\"quiz__correct-answers-title\">Solutions</h2><p class=\"quiz__correct-answers\">1:A</p><h3 class=\"quiz__scores-title\">Scores</h3><ol class=\"quiz__scores\"></ol></div>\n",
             "data" : {
               "quiz" : {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bump content-atom-model-thrift to version "11.0.0" to support new tags fields on content atom model.

The new fields are added here:
- https://github.com/guardian/content-atom/pull/211

## How has this change been tested?

This will be tested on the [corresponding PR for Concierge](https://github.com/guardian/content-api/pull/3347). 

## Relevant PRs
1. [content atom thrift model](https://github.com/guardian/content-atom/pull/211)
2. [atom-maker](https://github.com/guardian/atom-maker/pull/143)
3. [CAPI ElasticSearch mapping](https://github.com/guardian/content-api/pull/3345)
4. [CAPI Porter](https://github.com/guardian/content-api/pull/3346)
5. [CAPI Models](https://github.com/guardian/content-api-models/pull/303) <-- you are here
6. [CAPI Concierge](https://github.com/guardian/content-api/pull/3347)