### PR TITLE
Fix npm publishing - Update content-atom

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "4.0.0"
-val contentAtomVersion = "11.0.0"
+val contentAtomVersion = "11.0.1"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.1")
 
 addDependencyTreePlugin


### PR DESCRIPTION
Co-authored-by: Marjan K <15894063+marjisound@users.noreply.github.com>

## What does this change?

This PR updates:

- `content-atom` to v11.0.1 to fix NPM publishing
  following https://github.com/guardian/content-atom/pull/213

- `sbt-scrooge-typescript` plugin to v4.0.1
  following https://github.com/guardian/scrooge-extras/pull/59

NPM publishing of `content-api-models` as part of the [`release`](https://github.com/guardian/content-api-models/blob/9f587747aa2db3c845e92f7350642c5b5424d7a0/.github/workflows/release.yml#L16) workflow has been failing since Apr 23rd:

https://github.com/guardian/content-api-models/actions/workflows/release.yml?query=branch%3Amain

This due to an error in NPM publishing `content-atom` since v10.

This then means the release workflow `content-api-models` fails as it cannot find a matching versions for `content-atom`.

https://github.com/guardian/content-api-models/actions/runs/26153177060/job/76929613235#step:6:89
https://github.com/guardian/content-api-models/actions/runs/24823562567/job/72656684072#step:6:89

## How has this change been tested?

A preview release has been created and tested in a local application.

## After

https://www.npmjs.com/package/@guardian/content-api-models/v/40.0.1

<img width="1603" height="384" alt="Screenshot 2026-05-26 at 17 34 50" src="https://github.com/user-attachments/assets/eaf89bd1-e076-4055-9650-ad4397b4f898" />

