### PR TITLE
Add fallbackContent to InteractiveElementFields and add ResponsiveImageElement types

### DIFF
--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -244,4 +244,8 @@ object CirceDecoders {
   implicit val productCTADecoder: Decoder[ProductCTA] = deriveDecoder
   implicit val productImageDecoder: Decoder[ProductImage] = deriveDecoder
   implicit val productElementFieldsDecoder: Decoder[ProductElementFields] = deriveDecoder
+  implicit val colorSchemeDecoder: Decoder[ColorScheme] = deriveDecoder
+  implicit val responsiveImageVariantDecoder: Decoder[ResponsiveImageVariant] = deriveDecoder
+  implicit val responsiveImageVariantImageDecoder: Decoder[ResponsiveImageVariantImage] = deriveDecoder
+  implicit val responsiveImageElementFieldsDecoder: Decoder[ResponsiveImageElementFields] = deriveDecoder
 }

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -193,6 +193,10 @@ object CirceEncoders {
   implicit val productCTAEncoder: Encoder[ProductCTA] = deriveEncoder
   implicit val productImageEncoder: Encoder[ProductImage] = deriveEncoder
   implicit val productElementFieldsEncoder: Encoder[ProductElementFields] = deriveEncoder
+  implicit val colorSchemeEncoder: Encoder[ColorScheme] = deriveEncoder
+  implicit val responsiveImageVariantEncoder: Encoder[ResponsiveImageVariant] = deriveEncoder
+  implicit val responsiveImageVariantImageEncoder: Encoder[ResponsiveImageVariantImage] = deriveEncoder
+  implicit val responsiveImageElementFieldsEncoder: Encoder[ResponsiveImageElementFields] = deriveEncoder
 
   def genDateTimeEncoder(truncate: Boolean = true): Encoder[CapiDateTime] = Encoder.instance[CapiDateTime] { capiDateTime =>
     val dateTime: OffsetDateTime = OffsetDateTime.parse(capiDateTime.iso8601)

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -636,6 +636,12 @@ struct InteractiveElementFields {
 //    12: optional i32 height
 //    13: optional i32 width
     14: optional string sourceDomain
+    /**
+     * Fallback content to display if the platform is not able to render the
+     * content at `url`, for example because the platform does not support
+     * rendering HTML natively.
+     */
+    15: optional list<BlockElement> fallbackContent
 }
 
 struct StandardElementFields {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1088,6 +1088,60 @@ struct ProductElementFields {
   11: optional string id;
 }
 
+enum ColorScheme {
+    LIGHT = 0,
+    DARK = 1
+}
+
+struct ResponsiveImageVariant {
+    1: required string viewportSize;
+    2: required list<ResponsiveImageVariantImage> images;
+    3: optional ColorScheme colorScheme;
+}
+
+struct ResponsiveImageVariantImage {
+    /** The mime type of the image */
+    1: required string mimeType;
+
+    /** the url of the image file */
+    2: required string file;
+
+    /** The width of the image */
+    3: optional i32 width;
+
+    /** The height of the image */
+    4: optional i32 height;
+
+    /** The id of the image in the media api */
+    5: optional string mediaId;
+}
+
+/** Responsive image element */
+struct ResponsiveImageElementFields {
+    /**
+     * Lists of images to display at each responsive variant.
+     */
+    1: optional list<ResponsiveImageVariant> variants;
+
+    /** The role of the element (i.e. a hint about how it should be displayed) e.g. showcase, thumbnail, immersive */
+    2: optional string role;
+
+    3: optional string photographer;
+
+    4: optional string caption;
+
+    5: optional string alt;
+
+    /** The source of the image(s) */
+    6: optional string source;
+
+    /** If the credit should be displayed */
+    7: optional bool displayCredit;
+
+    /** Type of the image, usually one of Illustration, Photograph or Composite */
+    8: optional string imageType;
+}
+
 struct BlockElement {
 
     1: required ElementType type
@@ -1152,6 +1206,8 @@ struct BlockElement {
     28: optional LinkElementFields linkTypeData
 
     29: optional ProductElementFields productTypeData
+
+    30: optional ResponsiveImageElementFields responsiveImageTypeData
 }
 
 struct MembershipPlaceholder {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -154,6 +154,8 @@ enum ElementType {
     LINK = 25
 
     PRODUCT = 26
+
+    RESPONSIVE_IMAGE = 27
 }
 
 enum TagType {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -417,6 +417,8 @@ struct AssetFields {
   70: optional list<CartoonVariant> cartoonVariants
 
   71: optional string secureFileWithAds
+
+  72: optional list<ResponsiveImageVariant> responsiveImageVariants
 }
 
 struct Asset {
@@ -1119,9 +1121,9 @@ struct ResponsiveImageVariantImage {
 /** Responsive image element */
 struct ResponsiveImageElementFields {
     /**
-     * Lists of images to display at each responsive variant.
+     * Lists of images to display for each responsive variant.
      */
-    1: optional list<ResponsiveImageVariant> variants;
+    1: optional list<ResponsiveImageVariant> responsiveImageVariants;
 
     /** The role of the element (i.e. a hint about how it should be displayed) e.g. showcase, thumbnail, immersive */
     2: optional string role;


### PR DESCRIPTION
## What does this change?
Adds a `fallbackContent` field to interactive elements, and a new `ResponsiveImage` element. This will enable us to add images as fallback content for interactives that can't be displayed in Apple News. See the RFC here: https://github.com/guardian/flexible-model/discussions/98

## How has this change been tested?
We've tested this on CODE-AARDVARK and verified that a responsive image used as fallback content is correctly returned by CAPI.
