### PR TITLE
Bump to content-atom v12.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "4.0.0"
-val contentAtomVersion = "11.0.1"
+val contentAtomVersion = "12.0.1"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.23.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes


### PR DESCRIPTION
This adds a new optional parameter codecs for media atoms. See https://github.com/guardian/content-atom/pull/216