### PR TITLE
Update content-atom version to add football competition atom

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "4.0.0"
-val contentAtomVersion = "12.1.0-PREVIEW.add-new-atom-for-match-day.2026-06-29T0857.762a6566"
+val contentAtomVersion = "12.1.0-PREVIEW.add-new-atom-for-match-day.2026-07-15T1141.302c1611"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.23.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "4.0.0"
-val contentAtomVersion = "12.0.1"
+val contentAtomVersion = "12.1.0-PREVIEW.add-new-atom-for-match-day.2026-06-29T0857.762a6566"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.23.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -203,6 +203,7 @@ object CirceDecoders {
   implicit val audioAtomDecoder: Decoder[audio.AudioAtom] = deriveDecoder
   implicit val offPlatformDecoder: Decoder[audio.OffPlatform] = deriveDecoder
   implicit val emailSignUpAtomDecoder: Decoder[emailsignup.EmailSignUpAtom] = deriveDecoder
+  implicit val footballCompetitionAtomDecoder: Decoder[footballcompetition.FootballCompetitionAtom] = deriveDecoder
   implicit val atomDecoder: Decoder[contentatom.Atom] = deriveDecoder
   implicit val contentChangeDetailsDecoder: Decoder[contentatom.ContentChangeDetails] = deriveDecoder
   implicit val changeRecordDecoder: Decoder[contentatom.ChangeRecord] = deriveDecoder

--- a/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceDecoders.scala
@@ -203,7 +203,7 @@ object CirceDecoders {
   implicit val audioAtomDecoder: Decoder[audio.AudioAtom] = deriveDecoder
   implicit val offPlatformDecoder: Decoder[audio.OffPlatform] = deriveDecoder
   implicit val emailSignUpAtomDecoder: Decoder[emailsignup.EmailSignUpAtom] = deriveDecoder
-  implicit val footballCompetitionAtomDecoder: Decoder[footballcompetition.FootballCompetitionAtom] = deriveDecoder
+  implicit val tempFootballCompetitionAtomDecoder: Decoder[tempfootballcompetition.TempFootballCompetitionAtom] = deriveDecoder
   implicit val atomDecoder: Decoder[contentatom.Atom] = deriveDecoder
   implicit val contentChangeDetailsDecoder: Decoder[contentatom.ContentChangeDetails] = deriveDecoder
   implicit val changeRecordDecoder: Decoder[contentatom.ChangeRecord] = deriveDecoder

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -152,7 +152,7 @@ object CirceEncoders {
   implicit val audioAtomEncoder: Encoder[audio.AudioAtom] = deriveEncoder
   implicit val offPlatformEncoder: Encoder[audio.OffPlatform] = deriveEncoder
   implicit val emailSignUpAtomEncoder: Encoder[emailsignup.EmailSignUpAtom] = deriveEncoder
-  implicit val footballCompetitionAtomEncoder: Encoder[footballcompetition.FootballCompetitionAtom] = deriveEncoder
+  implicit val tempFootballCompetitionAtomEncoder: Encoder[tempfootballcompetition.TempFootballCompetitionAtom] = deriveEncoder
   implicit val atomEncoder: Encoder[contentatom.Atom] = deriveEncoder
   implicit val contentChangeDetailsEncoder: Encoder[contentatom.ContentChangeDetails] = deriveEncoder
   implicit val changeRecordEncoder: Encoder[contentatom.ChangeRecord] = deriveEncoder

--- a/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contentapi/json/CirceEncoders.scala
@@ -152,6 +152,7 @@ object CirceEncoders {
   implicit val audioAtomEncoder: Encoder[audio.AudioAtom] = deriveEncoder
   implicit val offPlatformEncoder: Encoder[audio.OffPlatform] = deriveEncoder
   implicit val emailSignUpAtomEncoder: Encoder[emailsignup.EmailSignUpAtom] = deriveEncoder
+  implicit val footballCompetitionAtomEncoder: Encoder[footballcompetition.FootballCompetitionAtom] = deriveEncoder
   implicit val atomEncoder: Encoder[contentatom.Atom] = deriveEncoder
   implicit val contentChangeDetailsEncoder: Encoder[contentatom.ContentChangeDetails] = deriveEncoder
   implicit val changeRecordEncoder: Encoder[contentatom.ChangeRecord] = deriveEncoder

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1830,6 +1830,8 @@ struct Atoms {
     16: optional list<contentatom.Atom> audios
 
     17: optional list<contentatom.Atom> emailsignups
+
+    18: optional list<contentatom.Atom> footballcompetitions
 }
 
 struct ContentStats {
@@ -2276,6 +2278,8 @@ struct ItemResponse {
     37: optional contentatom.Atom emailsignup
 
     38: optional list<Content> deeplyRead
+
+    39: optional contentatom.Atom footballcompetition
 }
 
 struct TagsResponse {

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1831,7 +1831,7 @@ struct Atoms {
 
     17: optional list<contentatom.Atom> emailsignups
 
-    18: optional list<contentatom.Atom> footballcompetitions
+    18: optional list<contentatom.Atom> tempfootballcompetitions
 }
 
 struct ContentStats {
@@ -2279,7 +2279,7 @@ struct ItemResponse {
 
     38: optional list<Content> deeplyRead
 
-    39: optional contentatom.Atom footballcompetition
+    39: optional contentatom.Atom tempfootballcompetition
 }
 
 struct TagsResponse {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Update content-atom version to add football competition atom which was updated in https://github.com/guardian/content-atom/pull/220