### PR TITLE
Update sbt-scrooge-typescript to 4.0.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.1")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.2-PREVIEW.update-thrift.2026-07-09T1430.28c2c948")
 
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.2-PREVIEW.update-thrift.2026-07-09T1430.28c2c948")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "4.0.2")
 
 addDependencyTreePlugin


### PR DESCRIPTION
## What does this change?

This PR updates the dependency on sbt-scrooge-typescript, coming from [scrooge-extras](https://github.com/guardian/scrooge-extras), to [4.0.2](https://github.com/guardian/scrooge-extras/releases/tag/v4.0.2). This gets the generated dependency on thrift in the typescript package to latest (0.23.0), which will help resolve a Dependabot vulnerability for consumers of the package.

## How has this change been tested?

Tested with a preview release from https://github.com/guardian/scrooge-extras/pull/64 via https://github.com/guardian/teleporter/pull/170