### PR TITLE
Test preview release of content-atom

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "4.0.0"
-val contentAtomVersion = "12.0.1"
+val contentAtomVersion = "13.0.0-PREVIEW.updatelibthrift-0240.2026-07-23T0915.6e12677d"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.24.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes


### PR DESCRIPTION
In this preview release of content-atom (created from https://github.com/guardian/content-atom/pull/222), I’ve updated libthrift to 0.24.0. By running the CI for this project (thanks to the new atom tests added in https://github.com/guardian/content-api-models/pull/323), we can gain confidence that it’s safe to update libthrift in content-atom.