### PR TITLE
Update content-atom to v13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 // dependency versions
 val contentEntityVersion = "4.0.0"
-val contentAtomVersion = "12.0.1"
+val contentAtomVersion = "13.0.0"
 val storyPackageVersion = "2.2.0"
 val thriftVersion = "0.24.0"
 val scroogeVersion = "22.1.0" // update plugins too if this version changes


### PR DESCRIPTION
The dependency on content-atom was introducing a transitive dependency on an old version of thrift which was being picked up in teleporter by yarn and flagged by our vulnerability reporting. This commit updates content-atom to a new version which is on a new version of thrift.